### PR TITLE
Add Gulden to bip44 standard.

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -87,6 +87,7 @@ index | hexa       | coin
    84 | 0x80000054 | Gridcoin
    85 | 0x80000055 | [Auroracoin](http://auroracoin.is/)
    86 | 0x80000056 | IXCoin
+   87 | 0x80000057 | [Gulden](https://Gulden.com/)
 
 Coin types will be added only if there is a wallet implementing BIP-0044 for desired coin.
 


### PR DESCRIPTION
Hello,

Please accept pull request to include Gulden in the bip44 standard - inclusion is needed for coinomi https://github.com/Gulden/coinomi-android and also our new android wallet that is currently under development.

Thanks,
Gulden dev team.