### PR TITLE
Add Monero to SLIP-0044

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -89,6 +89,7 @@ index | hexa       | coin
    86 | 0x80000056 | IXCoin
    87 | 0x80000057 | [Gulden](https://Gulden.com/)
    88 | 0x80000058 | [BitBean](http://bitbean.org/)
+   89 | 0x80000080 | [Monero](https://getmonero.org/)
 
 Coin types will be added only if there is a wallet implementing BIP-0044 for desired coin.
 

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -89,7 +89,7 @@ index | hexa       | coin
    86 | 0x80000056 | IXCoin
    87 | 0x80000057 | [Gulden](https://Gulden.com/)
    88 | 0x80000058 | [BitBean](http://bitbean.org/)
-   89 | 0x80000080 | [Monero](https://getmonero.org/)
+  128 | 0x80000080 | [Monero](https://getmonero.org/)
 
 Coin types will be added only if there is a wallet implementing BIP-0044 for desired coin.
 


### PR DESCRIPTION
Chosen due to 0x80000080 almost being a palindrome, which seemed important at the time;)