### PR TITLE
Adding MasterTrader coin

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -97,6 +97,7 @@ index | hexa       | coin
    90 | 0x8000005a | [Myriadcoin](http://myriadcoin.org)
    91 | 0x8000005b | [BitSend](http://bitsend.info)
    92 | 0x8000005c | [Unobtanium](http://http://unobtanium.uno/)
+   93 | 0x8000005d | [MasterTrader](https://github.com/CrypticApplications/MTR-Update/)
   100 | 0x80000064 | [BigUp](https://github.com/BigUps/)
   101 | 0x80000065 | [GameCredits](https://github.com/Gamecredits-Universe/)
   128 | 0x80000080 | [Monero](https://getmonero.org/)


### PR DESCRIPTION
Grabing the next available hardened coin index.
This will be implemented in https://www.coinvault.io