### PR TITLE
Adding Stratis and Dubaicoin

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -110,6 +110,8 @@ index | hexa       | coin
   101 | 0x80000065 | [GameCredits](https://github.com/Gamecredits-Universe/)
   102 | 0x80000066 | [Dollarcoins](https://github.com/dollarcoins/source)
   103 | 0x80000067 | [Zayedcoin](https://github.com/ZayedCoin/Zayedcoin)
+  104 | 0x80000068 | [Dubaicoin](https://github.com/DubaiCoinDev/DubaiCoin)
+  105 | 0x80000069 | [Stratis](https://github.com/stratisproject/stratisX)
   128 | 0x80000080 | [Monero](https://getmonero.org/)
   130 | 0x80000082 | [NavCoin](https://github.com/navcoindev/navcoin2)
 


### PR DESCRIPTION
Dubaicoin is not fully confirmed yet to be added to coinvault.io