### PR TITLE
Register Factom into the BIP44 directory

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -115,6 +115,7 @@ index | hexa       | coin
   105 | 0x80000069 | [Stratis](https://github.com/stratisproject/stratisX)
   128 | 0x80000080 | [Monero](https://getmonero.org/)
   130 | 0x80000082 | [NavCoin](https://github.com/navcoindev/navcoin2)
+  131 | 0x80000083 | [Factom](https://github.com/FactomProject)
 
 Coin types will be added only if there is a wallet implementing BIP-0044 for desired coin.
 


### PR DESCRIPTION
Please add Factom as a registered BIP44 type.  I assumed that the next highest descriptor (131) is available.