### PR TITLE
Handle both token types (Factoids + ECs) in Factom

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -115,7 +115,7 @@ index | hexa       | coin
   105 | 0x80000069 | [Stratis](https://github.com/stratisproject/stratisX)
   128 | 0x80000080 | [Monero](https://getmonero.org/)
   130 | 0x80000082 | [NavCoin](https://github.com/navcoindev/navcoin2)
-  131 | 0x80000083 | [Factom Factoids](https://github.com/FactomProject)
+  131 | 0x80000083 | [Factom Factoids](https://github.com/FactomProject/FactomDocs/blob/master/wallet_info/wallet_test_vectors.md)
   132 | 0x80000084 | [Factom Entry Credits](https://github.com/FactomProject)
 
 Coin types will be added only if there is a wallet implementing BIP-0044 for desired coin.

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -115,7 +115,8 @@ index | hexa       | coin
   105 | 0x80000069 | [Stratis](https://github.com/stratisproject/stratisX)
   128 | 0x80000080 | [Monero](https://getmonero.org/)
   130 | 0x80000082 | [NavCoin](https://github.com/navcoindev/navcoin2)
-  131 | 0x80000083 | [Factom](https://github.com/FactomProject)
+  131 | 0x80000083 | [Factom Factoids](https://github.com/FactomProject)
+  132 | 0x80000084 | [Factom Entry Credits](https://github.com/FactomProject)
 
 Coin types will be added only if there is a wallet implementing BIP-0044 for desired coin.
 


### PR DESCRIPTION
I thought the wallet manufacturer would prefer to use the different account indexes for the different coin types, but I was wrong.  A better solution for the wallet provider is to treat the two different tokens as different coin types.

Factom has two internal antispam tokens.  The transferable Factoids are converted to non-transferable Entry Credits, which are used to publish data into the blockchain.  They also use different addressing schemes and different pubkey constructions.

https://github.com/FactomProject/FactomDocs/blob/master/factomDataStructureDetails.md#factoid-transaction