### PR TITLE
Update slip-0044.md

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -121,6 +121,8 @@ index | hexa       | coin
   132 | 0x80000084 | [Factom Entry Credits](https://github.com/FactomProject)
   133 | 0x80000085 | [Zcash](https://z.cash)
   134 | 0x80000086 | [Lisk](https://lisk.io/)
+  135 | 0x80000087 | 
+  136 | 0x80000088 | [ZCoin](https://zcoin.tech)
 
 Coin types will be added only if there is a wallet implementing BIP-0044 for desired coin.
 


### PR DESCRIPTION
Following #47, we changed to 136 | 0x88 for ZCoin (https://zcoin.tech)