### PR TITLE
Remove Stratis 140 and change URL

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -113,7 +113,7 @@ index | hexa       | coin
   102 | 0x80000066 | [Dollarcoins](https://github.com/dollarcoins/source)
   103 | 0x80000067 | [Zayedcoin](https://github.com/ZayedCoin/Zayedcoin)
   104 | 0x80000068 | [Dubaicoin](https://github.com/DubaiCoinDev/DubaiCoin)
-  105 | 0x80000069 | [Stratis](https://github.com/stratisproject/stratisX)
+  105 | 0x80000069 | [Stratis](http://www.stratisplatform.com)
   106 | 0x8000006a | [Shilling](https://github.com/yavwa/Shilling)
   118 | 0x80000076 | [PiggyCoin](https://www.piggy-coin.com/)
   128 | 0x80000080 | [Monero](https://getmonero.org/)
@@ -127,7 +127,6 @@ index | hexa       | coin
   137 | 0x80000089 | [Rootstock](http://www.rsk.co/)
   138 | 0x8000008A | [Giftblock](https://github.com/gyft/giftblock)
   139 | 0x8000008B | [RealPointCoin](https://github.com/MaxSmile/RealPointCoinQt)
-  140 | 0x8000008C | [Stratis](http://www.stratisplatform.com)
 37310 | 0x800091BE | [Rootstock Testnet](http://www.rsk.co/)
 
 Coin types will be added only if there is a wallet implementing BIP-0044 for desired coin.


### PR DESCRIPTION
Received word that Stratis was already added by Coinvault at ID nr 105.
Removed 140 entry and altered the URL at 105.