### PR TITLE
Add Vertcoin bech32 addresses

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -27,6 +27,8 @@ hrp    | coin
 `tb`   | Bitcoin Testnet
 `ltc`  | [Litecoin](https://litecoin.org/)
 `tltc` | Litecoin Testnet
+`vtc`  | [Vertcoin](https://vertcoin.org/)
+`tvtc` | Vertcoin Testnet
 
 ## Libraries
 


### PR DESCRIPTION
Right now Vertcoin is using `vtc` and `tvtc` for main net and test net respectively.