### PR TITLE
slip-0044 : Add Bitcoin Cash

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -173,6 +173,7 @@ index | hexa       | coin
 142   | 0x8000008e | [bisq Token (BSQ)](http://bisq.io/)
 143   | 0x8000008f | [Riecoin (RIC)](https://github.com/riecoin/riecoin)
 144   | 0x80000090 | [Ripple (XRP)](https://ripple.com)
+145   | 0x80000091 | [Bitcoin Cash](https://www.bitcoincash.org)
 37310 | 0x800091be | [Rootstock Testnet](http://www.rsk.co/)
 
 Coin types will be added only if there is a wallet implementing BIP-0044 for desired coin.


### PR DESCRIPTION
If the chain launches on August 1st, there should be some interest for it, and the opt-in replay protection might make things messy. Handling both coins on different branches is an attempt to make it slightly better (users will be encouraged to split to use it, eliminating the Bitcoin Cash->Bitcoin replay risks)