### PR TITLE
Update slip for Bitcoin Cash Testnet

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -174,6 +174,7 @@ index | hexa       | coin
 143   | 0x8000008f | [Riecoin (RIC)](https://github.com/riecoin/riecoin)
 144   | 0x80000090 | [Ripple (XRP)](https://ripple.com)
 145   | 0x80000091 | [Bitcoin Cash](https://www.bitcoincash.org)
+146   | 0x80000092 | [Bitcoin Cash Testnet](https://www.bitcoincash.org)
 1337  | 0x80000090 | [Defcoin](http://defcoin-ng.org)
 37310 | 0x800091be | [Rootstock Testnet](http://www.rsk.co/)
 


### PR DESCRIPTION
Proposed registered coin id for Bitcoin Cash Testnet: 146