### PR TITLE
Add Bitcoin Gold to slip-0173

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -29,6 +29,8 @@ hrp    | coin
 `tltc` | Litecoin Testnet
 `vtc`  | [Vertcoin](https://vertcoin.org/)
 `tvtc` | Vertcoin Testnet
+`btg`  | [Bitcoin Gold](https://bitcoingold.org/)
+`tbtg` | Bitcoin Gold testnet
 
 ## Libraries
 


### PR DESCRIPTION
Bitcoin Gold will take `btg` for mainnet and `tbtg` for testnet bech32 addresses.