### PR TITLE
Add Bitcoin Platinum to slip-0173

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -21,12 +21,13 @@ The BIP repository does not want to deal with assigning the values for various c
 
 These are the registered human-readable parts for usage in Bech32 encoding of witness programs.
 
-hrp   | coin                                     | hrp    | coin                 |
-------|------------------------------------------|--------|----------------------|
-`bc`  | [Bitcoin](https://bitcoin.org/)          | `tb`   | Bitcoin Testnet      |
-`ltc` | [Litecoin](https://litecoin.org/)        | `tltc` | Litecoin Testnet     |
-`vtc` | [Vertcoin](https://vertcoin.org/)        | `tvtc` | Vertcoin Testnet     |
-`btg` | [Bitcoin Gold](https://bitcoingold.org/) | `tbtg` | Bitcoin Gold Testnet |
+hrp   | coin                                     | hrp    | coin                     |
+------|------------------------------------------|--------|--------------------------|
+`bc`  | [Bitcoin](https://bitcoin.org/)          | `tb`   | Bitcoin Testnet          |
+`ltc` | [Litecoin](https://litecoin.org/)        | `tltc` | Litecoin Testnet         |
+`vtc` | [Vertcoin](https://vertcoin.org/)        | `tvtc` | Vertcoin Testnet         |
+`btg` | [Bitcoin Gold](https://bitcoingold.org/) | `tbtg` | Bitcoin Gold Testnet     |
+`btg` | [Bitcoin Platinum](https://btcplt.org/)  | `tbtp` | Bitcoin Platinum Testnet |
 
 ## Libraries
 

--- a/slip-0173.md
+++ b/slip-0173.md
@@ -27,7 +27,7 @@ hrp   | coin                                     | hrp    | coin                
 `ltc` | [Litecoin](https://litecoin.org/)        | `tltc` | Litecoin Testnet         |
 `vtc` | [Vertcoin](https://vertcoin.org/)        | `tvtc` | Vertcoin Testnet         |
 `btg` | [Bitcoin Gold](https://bitcoingold.org/) | `tbtg` | Bitcoin Gold Testnet     |
-`btg` | [Bitcoin Platinum](https://btcplt.org/)  | `tbtp` | Bitcoin Platinum Testnet |
+`btp` | [Bitcoin Platinum](https://btcplt.org/)  | `tbtp` | Bitcoin Platinum Testnet |
 
 ## Libraries
 


### PR DESCRIPTION
Bitcoin Platinum will take btp for mainnet and tbtp for testnet bech32 addresses.