### PR TITLE
SLIP-48: Adding ref link to Graphene Wiki

### DIFF
--- a/slip-0048.md
+++ b/slip-0048.md
@@ -137,6 +137,7 @@ BitShares  | owner         | forth          | forth     | m / 48' / 1' / 0' / 3'
 ## References
 
 * [BIP-0044: Multi-Account Hierarchy for Deterministic Wallets](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki)
+* [Graphene Wiki](https://github.com/cryptonomex/graphene/wiki)
 
 ## Updates
 


### PR DESCRIPTION
When reading this SLIP, I had a difficult time locating basic info about Graphene.
Perhaps this link will help others (I also updated the Graphene wiki today, so it's a little more informative).