### PR TITLE
Fix BCS Path Index

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -208,7 +208,7 @@ index | hexa       | coin
 258   | 0x80000102 | [Zen Protocol](https://www.zenprotocol.com/)
 328   | 0x80000148 | [Blocknet](https://blocknet.co/)
 333   | 0x8000014d | [MemCoin](https://memcoin.org)
-505   | 0x800001f9 | [Bitcoin Smart (BCS)](http://bcs.info)
+555   | 0x8000022b | [Bitcoin Smart (BCS)](http://bcs.info)
 666   | 0x8000029a | [Achain](https://www.achain.com/)
 888   | 0x80000378 | [NEO (NEO)](https://neo.org/)
 999   | 0x80000643 | [Bitcoin Diamond (BCD)](http://btcd.io/)


### PR DESCRIPTION
Thank you for merging my previous pull request. But I wrote BCS's path index wrong. BCS's path index should be `555 (0x8000022b)` . Sorry for the mistake and the troubles I caused you.