### PR TITLE
Add Groestlcoin to SLIP-0173

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -29,6 +29,7 @@ hrp   | coin                                     | hrp    | coin                
 `btg` | [Bitcoin Gold](https://bitcoingold.org/) | `tbtg` | Bitcoin Gold Testnet     |
 `btp` | [Bitcoin Platinum](https://btcplt.org/)  | `tbtp` | Bitcoin Platinum Testnet |
 `zen` | [Zen Protocol](https://zenprotocol.com/) | `tzn`  | Zen Protocol Testnet     |
+`grs` | [Groestlcoin](https://groestlcoin.org/)  | `tgrs` | Groestlcoin Testnet      |
 
 ## Libraries
 


### PR DESCRIPTION
Add Groestlcoin to SLIP-0173 as these HRPs are implemented in the upcoming version of its Electrum fork.