### PR TITLE
Suggest changes to slip-0039

### DIFF
--- a/slip-0039.md
+++ b/slip-0039.md
@@ -33,12 +33,12 @@ In case sufficient M values are provided the points exactly define the polynomia
 
 ## From entropy to mnemonic secrets
 
-The value to be encoded as the master secret must be a multiple of 8 bits. This is typically a wallet entropy, but we do not restrict the usage in any way. The master secret is divided into N Shamir parts and M specifies how many of those parts do we need to reconstruct the master secret. We use GF(256) as the underlying field. We consider the master secret in a form which includes its own checksum:
+The value to be encoded as the master secret must be a multiple of 8 bits. This is typically a wallet entropy, but may be another secret value which was uniformly chosen from its (key) space. The master secret is divided into N Shamir parts and M specifies how many of those parts do we need to reconstruct the master secret. We use GF(256) reduced by x^8 + x^4 + x^3 + x + 1 (the Rijndael polynomial) as the underlying field. We consider the master secret in a form which includes its own checksum:
 
 | master secret | 16-bit master secret checksum |
 |---------------|-------------------------------|
 
-From this value the N parts are generated and each participating party receives the following data:
+From this value, every byte is mapped to the specified field in a little-endian fashion (i.e. the first bit maps to a_7, the last bit maps to a_0). For each field element (S), the N share-elements are generated and mapped back to bytes. Each participating party receives the following data:
 
 | 5-bit index | 5-bit M threshold | variable-bit SSSS part | 16-bit checksum |
 |-------------|-------------------|------------------------|-----------------|
@@ -69,17 +69,18 @@ This structure is then converted into a mnemonic passphrase by splitting it up b
 
 ## Checksum
 
-For checksum we use 16-bits of SHA-256 hash function.
+For the checksums we use the leftmost 16 bits of a SHA-256 hash digest of the relevant payload.
 
 ## Passphrase
 
 When enough M secrets are provided the master secret is reconstructed. To allow an additional protection of the final seed using a passphrase we suggest a following scenario. The passphrase is stretched using PBKDF2, which servers as a key to an AES encryption. The result of this encryption is the final seed to be used. If no passphrase is provided the passphrase is set to an empty string.
+(TODO: Use domain separation in PBKDF2)
 
 ![passphrase](slip-0039/passphrase.png)
 
 This mechanism is intentionally symmetric to allow reconstructing the master secret from the seed in case the passphrase is known.
 
-We propose to use 2048 rounds of PBKDF2 and 1 round of AES (TODO: which mode?).
+We propose to use 2000 rounds of PBKDF2 and one full computation of AES (TODO: which mode?).
 
 ## Versioning
 


### PR DESCRIPTION
**DISCLAIMER: These are just some suggestions. I did NOT perform a thorough security review of the methods specified in this document and cannot guarantee that there are no flaws left in this draft.**

Changes that were made:

- Specify explicitly which finite field is used, not only its order but also the irreducible polynomial by which it is reduced.
- Specify the mapping of the key bytes and the finite field in which the secret sharing is computed.
- Why use 2048 PBKDF2 rounds? Why not a round number like 2000/2500/etc.?
- The current version suggest using one round of AES, which would be terribly insecure! Use  at least a full computation.