### PR TITLE
slip-0039: no index/threshold encoding

### DIFF
--- a/slip-0039.md
+++ b/slip-0039.md
@@ -45,17 +45,7 @@ From this value, every byte is mapped to the specified field in a little-endian 
 
 The index corresponds to the SSSS part's `x` value (see the diagram above) and the SSSS part is the corresponding `y` value.
 
-Index and threshold are encoding using the following scheme (convert from bits to decimal and add 1):
-
-| 5-bit value | index/threshold value |
-|-------------|-----------------------|
-| 00000       | 1                     |
-| 00001       | 2                     |
-| 00010       | 3                     |
-| ...         | ...                   |
-| 11101       | 30                    |
-| 11110       | 31                    |
-| 11111       | 32                    |
+Index and threshold are encoded as 5-bit integers and the value 00000 is considered as invalid in both cases. 
 
 The checksum field is a checksum of the whole share (i.e. index, threshold, SSSS part).
 


### PR DESCRIPTION
I still think the index/threshold encoding can do more harm than good. Gaining one more share just seems not worth it. To be discussed

Also, I'm not sure we came to a conclusion regarding if we want to add a word "shamir" or similar in front of the mnemonic.
