### PR TITLE
Add SLIP-0132: Registered HD version bytes for BIP-0032

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Each SLIP should provide a concise technical specification of the feature and a 
 | [SLIP-0039](slip-0039.md) | Shamir's Secret-Sharing for Mnemonic Codes                            | Standard      | Draft    |
 | [SLIP-0044](slip-0044.md) | Registered coin types for BIP-0044                                    | Standard      | Draft    |
 | [SLIP-0048](slip-0048.md) | Deterministic key hierarchy for Graphene-based networks               | Informational | Draft    |
-| [SLIP-0173](slip-0173.md) | Registered human-readable parts for BIP-0173                          | Standard      | Draft    |
+| [SLIP-0132](slip-0132.md) | Registered human-readable parts for BIP-0173                          | Standard      | Draft    |
+| [SLIP-0173](slip-0173.md) | Registered HD version bytes for BIP-0032                              | Standard      | Draft    |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Each SLIP should provide a concise technical specification of the feature and a 
 | [SLIP-0039](slip-0039.md) | Shamir's Secret-Sharing for Mnemonic Codes                            | Standard      | Draft    |
 | [SLIP-0044](slip-0044.md) | Registered coin types for BIP-0044                                    | Standard      | Draft    |
 | [SLIP-0048](slip-0048.md) | Deterministic key hierarchy for Graphene-based networks               | Informational | Draft    |
-| [SLIP-0132](slip-0132.md) | Registered human-readable parts for BIP-0173                          | Standard      | Draft    |
-| [SLIP-0173](slip-0173.md) | Registered HD version bytes for BIP-0032                              | Standard      | Draft    |
+| [SLIP-0132](slip-0132.md) | Registered HD version bytes for BIP-0032                              | Standard      | Draft    |
+| [SLIP-0173](slip-0173.md) | Registered human-readable parts for BIP-0173                          | Standard      | Draft    |
 
 ---
 

--- a/slip-0132.md
+++ b/slip-0132.md
@@ -1,0 +1,45 @@
+# SLIP-0132 : Registered HD version bytes for BIP-0032
+
+```
+Number:  SLIP-0132
+Title:   Registered HD version bytes for BIP-0032
+Type:    Standard
+Status:  Draft
+Authors: Clark Moody <clark@clarkmoody.com>
+Created: 2018-02-08
+```
+
+## Abstract
+
+BIP-0032 defines the derivation scheme for heirarchical deterministic wallets, which encode their public and private keys in an extended serialization format known as `xpub`. The `xpub` prefix is an artifact of Base58 encoding the four version bytes of the serialization format.
+
+## Motivation
+
+The BIP repository defines public and private key version bytes for Bitcoin's mainnet and testnet. However, other cryptocurrencies use different version bytes for encoding HD seeds, and the BIP repository is focused on Bitcoin. Thus, we propose this SLIP act as a registry for all coin HD version bytes.
+
+Since BIP-0032 does not specify the address format for a given derivation path, wallet developers [have proposed](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2017-September/014907.html) altering the version bytes to achieve this. With the activation of SegWit on Bitcoin, the number of ways of encoding an address public key has increased. While [BIP-0049](https://github.com/bitcoin/bips/blob/master/bip-0049.mediawiki) proposes a method for encoding P2WPKH-nested-in-P2SH addresses, it fails to change the HD seed version bytes (retains `xpub` prefix), leading to unsustainable user confusion. Either the user must know that the `xpub` uses BIP-0049 derivation, or the consumer of the `xpub` must scan both address spaces (P2PKH and P2WPKH-in-P2SH).
+
+[BIP-0084](https://github.com/bitcoin/bips/blob/master/bip-0084.mediawiki) proposes a native-SegWit derivation scheme, encoding P2WPKH addresses in Bech32. However, the extended serialization format is presented with a `zpub` prefix but no version bytes. This is an issue since multiple values of the version bytes may encode to the same prefix.
+
+A final important motiviation for establishing a clearinghouse of HD version bytes is the fact that the extended serialization format does not encode the coin type. The [SLIP-0032](https://github.com/satoshilabs/slips/blob/master/slip-0032.md) proposal attempts a remedy by including the full BIP-0032 derivation path within the serialized key. Along with a human-readable prefix of `xpub` and Bech32 encoding, SLIP-0032 should greatly improve the wallet ecosystem. Until wallets begin implementation of SLIP-0032, however, this registry aims to alleviate the confusion.
+
+## Registered HD version bytes
+
+These are the registered HD version bytes for extended serialization of public and private keys.
+
+Coin                                      | Public Key            | Private Key           | Address Encoding |
+------------------------------------------|-----------------------|-----------------------|------------------|
+[Bitcoin](https://bitcoin.org/)           | `0x0488b21e` - `xpub` | `0x0488ade4` - `xprv` | P2PKH or P2SH    |
+Bitcoin                                   | `0x049d7cb2` - `ypub` | `0x049d7878` - `yprv` | P2WPKH in P2SH   |
+Bitcoin                                   | `0x0295b43f` - `Ypub` | `0x0295b005` - `Yprv` | P2WSH in P2SH    |
+Bitcoin                                   | `0x04b24746` - `zpub` | `0x04b2430c` - `zprv` | P2WPKH           |
+Bitcoin                                   | `0x02aa7ed3` - `Zpub` | `0x02aa7a99` - `Zprv` | P2WSH            |
+Bitcoin Testnet                           | `0x043587cf` - `tpub` | `0x04358394` - `tprv` | P2PKH or P2SH    |
+[Litecoin](https://litecoin.org/)         | `0x019da462` - `Ltub` | `0x019d9cfe` - `Ltpv` | P2PKH or P2SH    |
+Litecoin Testnet                          | `0x0436f6e1` - `ttub` | `0x0436ef7d` - `ttpv` | P2PKH or P2SH    |
+[Vertcoin](https://vertcoin.org/)         | `0x0488b21e` - `vtcp` | `0x0488ade4` - `vtcv` | P2PKH or P2SH    |
+
+## References
+
+* [BIP-0032: Heirarchical Deterministic Wallets # Serialization](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#serialization-format)
+* [SLIP-0032 : Extended serialization format for BIP-32 wallets](https://github.com/satoshilabs/slips/blob/master/slip-0032.md)


### PR DESCRIPTION
Addresses #195 by adding all known Bitcoin HD version bytes, Litecoin, and Vertcoin.