### PR TITLE
SLIP-0132: Add Bitcoin HD seed test vectors

### DIFF
--- a/slip-0132.md
+++ b/slip-0132.md
@@ -41,6 +41,32 @@ Litecoin                                  | `0x01b26ef6` - `Mtub` | `0x01b26792`
 Litecoin Testnet                          | `0x0436f6e1` - `ttub` | `0x0436ef7d` - `ttpv` | P2PKH or P2SH    |
 [Vertcoin](https://vertcoin.org/)         | `0x0488b21e` - `vtcp` | `0x0488ade4` - `vtcv` | P2PKH or P2SH    |
 
+## Bitcoin Test Vectors
+
+```
+Mnemonic: abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about
+
+m/44'/0'/0'
+xprv9xpXFhFpqdQK3TmytPBqXtGSwS3DLjojFhTGht8gwAAii8py5X6pxeBnQ6ehJiyJ6nDjWGJfZ95WxByFXVkDxHXrqu53WCRGypk2ttuqncb
+xpub6BosfCnifzxcFwrSzQiqu2DBVTshkCXacvNsWGYJVVhhawA7d4R5WSWGFNbi8Aw6ZRc1brxMyWMzG3DSSSSoekkudhUd9yLb6qx39T9nMdj
+m/44'/0'/0'/0/0 address:
+1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA
+
+m/49'/0'/0'
+yprvAHwhK6RbpuS3dgCYHM5jc2ZvEKd7Bi61u9FVhYMpgMSuZS613T1xxQeKTffhrHY79hZ5PsskBjcc6C2V7DrnsMsNaGDaWev3GLRQRgV7hxF
+ypub6Ww3ibxVfGzLrAH1PNcjyAWenMTbbAosGNB6VvmSEgytSER9azLDWCxoJwW7Ke7icmizBMXrzBx9979FfaHxHcrArf3zbeJJJUZPf663zsP
+m/49'/0'/0'/0/0 address:
+37VucYSaXLCAsxYyAPfbSi9eh4iEcbShgf
+
+m/84'/0'/0'
+zprvAdG4iTXWBoARxkkzNpNh8r6Qag3irQB8PzEMkAFeTRXxHpbF9z4QgEvBRmfvqWvGp42t42nvgGpNgYSJA9iefm1yYNZKEm7z6qUWCroSQnE
+zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs
+m/84'/0'/0'/0/0 address:
+bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu
+```
+
+[Test vectors generation code](https://gist.github.com/clarkmoody/0a788d2e012ffe339bb7d3873e47c081)
+
 ## References
 
 * [BIP-0032: Heirarchical Deterministic Wallets # Serialization](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#serialization-format)


### PR DESCRIPTION
Adds examples of HD seeds derived from a common mnemonic according to BIP-44, BIP-49, and BIP84. These are for Bitcoin only.

Test vectors were requested [here](https://github.com/MetacoSA/NBitcoin.Litecoin/issues/5#issuecomment-364342193).