### PR TITLE
SLIP-0132: Add Bitcoin testnet HD seed vector for P2WPKH and P2WSH

### DIFF
--- a/slip-0132.md
+++ b/slip-0132.md
@@ -36,6 +36,8 @@ Bitcoin                                   | `0x04b24746` - `zpub` | `0x04b2430c`
 Bitcoin                                   | `0x02aa7ed3` - `Zpub` | `0x02aa7a99` - `Zprv` | P2WSH            |
 Bitcoin Testnet                           | `0x043587cf` - `tpub` | `0x04358394` - `tprv` | P2PKH or P2SH    |
 Bitcoin Testnet                           | `0x044a5262` - `upub` | `0x044a4e28` - `uprv` | P2WPKH in P2SH   |
+Bitcoin Testnet                           | `0x045f1cf6` - `vpub` | `0x045f18bc` - `vprv` | P2WPKH           |
+Bitcoin Testnet                           | `0x02575483` - `Vpub` | `0x02575048` - `Vprv` | P2WSH            |
 [Litecoin](https://litecoin.org/)         | `0x019da462` - `Ltub` | `0x019d9cfe` - `Ltpv` | P2PKH or P2SH    |
 Litecoin                                  | `0x01b26ef6` - `Mtub` | `0x01b26792` - `Mtpv` | P2WPKH in P2SH   |
 Litecoin Testnet                          | `0x0436f6e1` - `ttub` | `0x0436ef7d` - `ttpv` | P2PKH or P2SH    |


### PR DESCRIPTION
Add Bitcoin testnet HD seed vector for P2WPKH(`0x045f1cf6` = `vpub`, `0x045f18bc` = `vprv`) and P2WSH(`0x02575483` = `Vpub`, `0x02575048` = `Vprv`).

These are already used in [electrum code](https://github.com/spesmilo/electrum/blob/381de43cace42c8aa160205f32ad8584793f00ad/lib/bitcoin.py#L91-L104).