### PR TITLE
Added Beetle Coin to slip-0044

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -247,6 +247,7 @@ index | hexa       | symbol | coin
 555   | 0x8000022b | BCS    | [Bitcoin Smart](http://bcs.info)
 666   | 0x8000029a | ACT    | [Achain](https://www.achain.com/)
 777   | 0x80000309 | BTW    | [Bitcoin World](http://btw.one)
+800   | 0x80000320 | BEET   | [Beetle Coin](https://beetlecoin.io/)
 808   | 0x80000328 | QVT    | [Qvolta](https://qvolta.com)
 820   | 0x80000334 | CLO    | [Callisto](http://callisto.network/)
 888   | 0x80000378 | NEO    | [NEO](https://neo.org/)


### PR DESCRIPTION
We are busy developing a BIP44 wallet for Beetle Coin, and would like to request this addition to the SLIP-044 if possible please. Thanks.