### PR TITLE
Requesting 1729' for Tezos

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -260,7 +260,7 @@ index | hexa       | symbol | coin
 1337  | 0x80000539 | DFC    | [Defcoin](http://defcoin-ng.org)
 1524  | 0x800005f4 |        | [Taler](http://taler.site)
 1688  | 0x80000698 | BCX    | [BitcoinX](https://bcx.org)
-1729  | 0x800004ff | XTZ    | [Tezos](https://tezos.com)
+1729  | 0x800006c1 | XTZ    | [Tezos](https://tezos.com)
 1815  | 0x80000717 | ADA    | [Cardano](https://www.cardanohub.org/en/home/)
 1977  | 0x800007b9 | XMX    | [Xuma](http://www.xumacoin.org/)
 1987  | 0x800007c3 | EGEM   | [EtherGem](https://egem.io)

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -260,6 +260,7 @@ index | hexa       | symbol | coin
 1337  | 0x80000539 | DFC    | [Defcoin](http://defcoin-ng.org)
 1524  | 0x800005f4 |        | [Taler](http://taler.site)
 1688  | 0x80000698 | BCX    | [BitcoinX](https://bcx.org)
+1729  | 0x800004ff | XTZ    | [Tezos](https://tezos.com)
 1815  | 0x80000717 | ADA    | [Cardano](https://www.cardanohub.org/en/home/)
 1977  | 0x800007b9 | XMX    | [Xuma](http://www.xumacoin.org/)
 1987  | 0x800007c3 | EGEM   | [EtherGem](https://egem.io)


### PR DESCRIPTION
Tezos currently uses ed25519 and is implementing bip32-ed25519 (which may use a different nomenclature). However, it does plan on using secp256k1 signatures as well so, all-in-all, it makes sense to reserve a bip44 constant.