### PR TITLE
Add EAST support

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -252,6 +252,7 @@ index | hexa       | symbol | coin
 510   | 0x800001fe | KOTO   | [Koto](https://koto.cash/)
 512   | 0x80000200 | XRD    | [Radiant](https://radiant.cash/)
 555   | 0x8000022b | BCS    | [Bitcoin Smart](http://bcs.info)
+625   | 0x80000271 | EAST   | [Eastcoin](http://easthub.io/)
 666   | 0x8000029a | ACT    | [Achain](https://www.achain.com/)
 668   | 0x8000029c | SSC    | [SelfSell](https://www.selfsell.com/)
 777   | 0x80000309 | BTW    | [Bitcoin World](http://btw.one)


### PR DESCRIPTION
Eastcoin is an ethereum fork coin for travelers ( See more info on http://easthub.io)

We would like to reserve 625 as a chainid / networkid / hwpath m/44'/625'/0'/0/0