### PR TITLE
Add Ethereum Social support

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -266,6 +266,7 @@ index | hexa       | symbol | coin
 999   | 0x800003e7 | BCD    | [Bitcoin Diamond](http://btcd.io/)
 1000  | 0x800003e8 | BTN    | [Bitcoin New](http://bitcoinnew.org/)
 1111  | 0x80000457 | BBC    | [Big Bitcoin](http://bigbitcoins.org/)
+1128  | 0x80000468 | ETSC   | [Ethereum Social](https://ethereumsocial.kr/)
 1145  | 0x80000479 | CDY    | [Bitcoin Candy](http://www.bitcoincandy.one)
 1337  | 0x80000539 | DFC    | [Defcoin](http://defcoin-ng.org)
 1524  | 0x800005f4 |        | [Taler](http://taler.site)


### PR DESCRIPTION
Ethereum Social is a Community enterprised blockchain platform based on ethereum. ( See more info on https://ethereumsocial.kr)

We would like to reserve 1128 as a chainid / networkid / hwpath m/44'/1128'/0'/0/0.