### PR TITLE
Added kUSD

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -303,6 +303,7 @@ index | hexa       | symbol | coin
 5249353 | 0x80501949 | BCO    | [BitcoinOre](http://bitcoinore.org/)
 5718350 | 0x8057414e | WAN    | [Wanchain](https://wanchain.org/)
 5741564 | 0x80579bfc | WAVES  | [Waves](https://wavesplatform.com/)
+91927009 | 0x857ab1e1 | kUSD   | [kUSD](https://kowala.tech)
 
 Coin types will be added only if there is a wallet implementing BIP-0044 for desired coin.
 


### PR DESCRIPTION
Hello! 

This adds [kUSD](https://kowala.tech) to the registered coin types in SLIP-0044. 

Because the new index is one character longer than the previously highest index, the columns are shifted to the right. I think that's okay because it follows the established convention, but do let me know if it isn't.

There's also some disagreement out whether or not to include a trailing slash on the URL; I've elected not to because that's very slightly more efficient.