### PR TITLE
SLIP-0044: Add VeChain Token

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -264,6 +264,7 @@ index | hexa       | symbol | coin
 777   | 0x80000309 | BTW    | [Bitcoin World](http://btw.one)
 800   | 0x80000320 | BEET   | [Beetle Coin](https://beetlecoin.io/)
 808   | 0x80000328 | QVT    | [Qvolta](https://qvolta.com)
+818   | 0x80000332 | VET    | [VeChain Token](https://vechain.com/)
 820   | 0x80000334 | CLO    | [Callisto](http://callisto.network/)
 886   | 0x80000376 | ADF    | [AD Token](http://adfunds.org)
 888   | 0x80000378 | NEO    | [NEO](https://neo.org/)


### PR DESCRIPTION
Add request for VeChain Token (VET), the coin for the [VeChain](https://vechain.com/) platform.