### PR TITLE
SLIP-0044: Add Yapstone

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -257,6 +257,7 @@ index | hexa       | symbol | coin
 444   | 0x800001bc | PHR    | [Phore](https://phore.io)
 510   | 0x800001fe | KOTO   | [Koto](https://koto.cash/)
 512   | 0x80000200 | XRD    | [Radiant](https://radiant.cash/)
+528   | 0x80000210 | YAP    | [Yapstone](https://yapstone.pro/)
 555   | 0x8000022b | BCS    | [Bitcoin Smart](http://bcs.info)
 625   | 0x80000271 | EAST   | [Eastcoin](http://easthub.io/)
 666   | 0x8000029a | ACT    | [Achain](https://www.achain.com/)


### PR DESCRIPTION
Reserving 528 as a chainid / networkid / hwpath m/44'/528'/0'/0/0 for Yapstone.