### PR TITLE
BIP44) Add EOS Classic support

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -285,6 +285,7 @@ index | hexa       | symbol | coin
 1987  | 0x800007c3 | EGEM   | [EtherGem](https://egem.io)
 1989  | 0x800007c5 | HODL   | [HOdlcoin](https://hodlcoin.com/)
 1997  | 0x800007cd | POLIS  | [Polis](https://polispay.org/)
+2018  | 0x80000‭7e2‬ | EOSC   | [EOSClassic](https://eos-classic.io/)
 2301  | 0x800008fd | QTUM   | [QTUM](https://qtum.org/en/)
 2302  | 0x800008fe | ETP    | [Metaverse](https://mvs.org/)
 3552  | 0x80000de0 | DEO    | [Destocoin](https://desto.io)


### PR DESCRIPTION
EOS Classic is a combination of EOS & ETH protocol

+ Homepage: https://eos-classic.io
+ Node: https://node.eos-classic.io
+ BIP44 / Chainid 2018