### PR TITLE
Add GoChain GO support

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -292,6 +292,7 @@ index | hexa       | symbol | coin
 2718  | 0x80000a9e | NAS    | [Nebulas](https://nebulas.io/)
 4218  | 0x8000107a | IOTA   | [IOTA](https://www.iota.org/)
 4242  | 0x80001092 | AXE    | [Axe](https://github.com/AXErunners/axe)
+6060  | 0x800017ac | GO     | [GoChain GO](https://gochain.io/)
 6666  | 0x80001a0a | BPA    | [Bitcoin Pizza](http://p.top/)
 6688  | 0x80001a20 | SAFE   | [SAFE](http://www.anwang.com/)
 7777  | 0x80001e61 | BTV    | [Bitvote](https://www.bitvote.one)


### PR DESCRIPTION
GoChain is a scalable, Ethereum based smart contract blockchain that is fast, secure and green.

- Homepage: https://gochain.io/
- BIP44 / Chainid 6060
