### PR TITLE
Add stacks coin-type

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -296,6 +296,7 @@ index | hexa       | symbol | coin
 2718  | 0x80000a9e | NAS    | [Nebulas](https://nebulas.io/)
 4218  | 0x8000107a | IOTA   | [IOTA](https://www.iota.org/)
 4242  | 0x80001092 | AXE    | [Axe](https://github.com/AXErunners/axe)
+5757  | 0x8000167D |        | [Stacks](https://github.com/blockstack/blockstack-core)
 6060  | 0x800017ac | GO     | [GoChain GO](https://gochain.io/)
 6666  | 0x80001a0a | BPA    | [Bitcoin Pizza](http://p.top/)
 6688  | 0x80001a20 | SAFE   | [SAFE](http://www.anwang.com/)


### PR DESCRIPTION
Stacks are the upcoming token on the blockstack network (testnet at https://testnet.blockstack.org/)