### PR TITLE
SLIP0010: fix different expressions for reulting child key

### DIFF
--- a/slip-0010.md
+++ b/slip-0010.md
@@ -92,9 +92,10 @@ The function CKDpriv((k<sub>par</sub>, c<sub>par</sub>), i) &rarr; (k<sub>i</sub
 2. Split I into two 32-byte sequences, I<sub>L</sub> and I<sub>R</sub>.
 3. The returned chain code c<sub>i</sub> is I<sub>R</sub>.
 4. If curve is ed25519: The returned child key k<sub>i</sub> is parse<sub>256</sub>(I<sub>L</sub>).
-5. If parse<sub>256</sub>(I<sub>L</sub>) + k<sub>par</sub> (mod n) ≥ n or parse<sub>256</sub>(I<sub>L</sub>) + k<sub>par</sub> (mod n) = 0 (resulting key is invalid):
+5. Set resulting key k<sub>i</sub>
+6. If k<sub>i</sub> ≥ n or k<sub>i</sub> = 0 (resulting key is invalid):
     * let I = HMAC-SHA512(Key = c<sub>par</sub>, Data = 0x01 || I<sub>R</sub> || ser<sub>32</sub>(i) and restart at step 2.
-6. Otherwise: The returned child key k<sub>i</sub> is parse<sub>256</sub>(I<sub>L</sub>) + k<sub>par</sub> (mod n).
+7. Otherwise: The returned child key k<sub>i</sub>.
 
 The HMAC-SHA512 function is specified in [RFC 4231](http://tools.ietf.org/html/rfc4231).
 

--- a/slip-0010.md
+++ b/slip-0010.md
@@ -92,7 +92,7 @@ The function CKDpriv((k<sub>par</sub>, c<sub>par</sub>), i) &rarr; (k<sub>i</sub
 2. Split I into two 32-byte sequences, I<sub>L</sub> and I<sub>R</sub>.
 3. The returned chain code c<sub>i</sub> is I<sub>R</sub>.
 4. If curve is ed25519: The returned child key k<sub>i</sub> is parse<sub>256</sub>(I<sub>L</sub>).
-5. If parse<sub>256</sub>(I<sub>L</sub>) ≥ n or parse<sub>256</sub>(I<sub>L</sub>) + k<sub>par</sub> = 0 (resulting key is invalid):
+5. If parse<sub>256</sub>(I<sub>L</sub>) + k<sub>par</sub> (mod n) ≥ n or parse<sub>256</sub>(I<sub>L</sub>) + k<sub>par</sub> (mod n) = 0 (resulting key is invalid):
     * let I = HMAC-SHA512(Key = c<sub>par</sub>, Data = 0x01 || I<sub>R</sub> || ser<sub>32</sub>(i) and restart at step 2.
 6. Otherwise: The returned child key k<sub>i</sub> is parse<sub>256</sub>(I<sub>L</sub>) + k<sub>par</sub> (mod n).
 


### PR DESCRIPTION
Before, we checked

* `I_L` for >= n
* `I_L + k_par` for 0

and returned `I_L + k_par (mod n)`.

Both those 3 expressions should be the same in order to avoid returning a key >= n or equal to 0.