### PR TITLE
Add Flo coin

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -240,6 +240,7 @@ index | hexa       | symbol | coin
 210   | 0x800000d2 | NEET   | [NEETCOIN](https://neetcoin.jp/)
 211   | 0x800000d3 | BOPO   | [BopoChain](http://www.bopochain.org/)
 215   | 0x800000d7 | BOXY   | [BoxyCoin](http://www.boxycoin.org/)
+216   | 0x800000d8 | FLO    | [Flo](https://www.flo.cash/)
 222   | 0x800000de | BITG   | [Bitcoin Green](https://savebitcoin.io)
 223   | 0x800000df | ASK    | [AskCoin](https://askcoin.org)
 224   | 0x800000e0 | SMART  | [Smartcash](https://smartcash.cc)


### PR DESCRIPTION
This adds Flo and defines it at index 216. You can find the implementation of this BIP44 wallet here: 

https://github.com/oipwg/oip-hdmw
https://github.com/oipwg/oip-hdmw/blob/26be43a7f34db089cd9ec6733a4922c5f2ac32fc/src/networks/flo.js#L100