### PR TITLE
New coins and table format

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -21,20 +21,23 @@ The BIP repository does not want to deal with assigning the values for various c
 
 These are the registered human-readable parts for usage in Bech32 encoding of witness programs.
 
-hrp   | coin                                       | hrp    | coin                     |
-------|--------------------------------------------|--------|--------------------------|
-`bc`  | [Bitcoin](https://bitcoin.org/)            | `tb`   | Bitcoin Testnet          |
-`ltc` | [Litecoin](https://litecoin.org/)          | `tltc` | Litecoin Testnet         |
-`vtc` | [Vertcoin](https://vertcoin.org/)          | `tvtc` | Vertcoin Testnet         |
-`btg` | [Bitcoin Gold](https://bitcoingold.org/)   | `tbtg` | Bitcoin Gold Testnet     |
-`btp` | [Bitcoin Platinum](https://btcplt.org/)    | `tbtp` | Bitcoin Platinum Testnet |
-`zen` | [Zen Protocol](https://zenprotocol.com/)   | `tzn`  | Zen Protocol Testnet     |
-`grs` | [Groestlcoin](https://groestlcoin.org/)    | `tgrs` | Groestlcoin Testnet      |
-`via` | [Viacoin](https://viacoin.org/)            | `tvia` | Viacoin Testnet          |
-`fc`  | [FujiCoin](http://www.fujicoin.org/)       | `tf`   | FujiCoin Testnet         |
-`bca` | [Bitcoin Atom](https://bitcoinatom.io/)    | `tbca` | Bitcoin Atom Testnet     |
-`p`   | [Bitcoin Private](https://btcprivate.org/) | `t`    | Bitcoin Private Testnet  |
-`btx` | [Bitcore](https://bitcore.cc/)             | `tbtx` | Bitcore Testnet          |
+| Coin                                       | Mainnet | Testnet | Regtest |
+| ------------------------------------------ | ------- | ------- | ------- |
+| [Bitcoin](https://bitcoin.org/)            | `bc`    | `tb`    | `bcrt`  |
+| [Bitcoin Atom](https://bitcoinatom.io/)    | `bca`   | `tbca`  | `bcart` |
+| [Bitcoin Gold](https://bitcoingold.org/)   | `btg`   | `tbtg`  |         |
+| [Bitcoin Platinum](https://btcplt.org/)    | `btp`   | `tbtp`  |         |
+| [Bitcoin Private](https://btcprivate.org/) | `p`     | `t`     |         |
+| [Bitcore](https://bitcore.cc/)             | `btx`   | `tbtx`  |         |
+| [DigiByte](https://www.digibyte.io/)       | `dgb`   | `dgbt`  | `dgbrt` |
+| [FujiCoin](http://www.fujicoin.org/)       | `fc`    | `tf`    | `fcrt`  |
+| [Groestlcoin](https://groestlcoin.org/)    | `grs`   | `tgrs`  |         |
+| [Litecoin](https://litecoin.org/)          | `ltc`   | `tltc`  | `rltc`  |
+| [Namecoin](https://www.namecoin.org/)      | `nc`    | `tn`    | `ncrt`  |
+| [Ravencon](https://ravencoin.org/)         | `rc`    | `tr`    | `rcrt`  |
+| [Vertcoin](https://vertcoin.org/)          | `vtc`   | `tvtc`  |         |
+| [Viacoin](https://viacoin.org/)            | `via`   | `tvia`  |         |
+| [Zen Protocol](https://zenprotocol.com/)   | `zen`   | `tzn`   |         |
 
 ## Libraries
 


### PR DESCRIPTION
Adds DigiByte, Ravencoin, Namecoin

Reformats table with one column for coin and three columns for mainnet, testnet, and regtest prefixes.