### PR TITLE
[SLIP-0173] Update testnet + regtest bech32_hrp for Bitcoin Private

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -27,7 +27,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | [Bitcoin Atom](https://bitcoinatom.io/)    | `bca`   | `tbca`  | `bcart` |
 | [Bitcoin Gold](https://bitcoingold.org/)   | `btg`   | `tbtg`  |         |
 | [Bitcoin Platinum](https://btcplt.org/)    | `btp`   | `tbtp`  |         |
-| [Bitcoin Private](https://btcprivate.org/) | `p`     | `t`     |         |
+| [Bitcoin Private](https://btcprivate.org/) | `p`     | `test`  | `rtest` |
 | [Bitcore](https://bitcore.cc/)             | `btx`   | `tbtx`  |         |
 | [DigiByte](https://www.digibyte.io/)       | `dgb`   | `dgbt`  | `dgbrt` |
 | [FujiCoin](http://www.fujicoin.org/)       | `fc`    | `tf`    | `fcrt`  |


### PR DESCRIPTION
For testnet, `test` should be used instead of `t`; Zcash/Zclassic base58check addresses begin with `t`, which could confuse users.

For regtest, `rtest` has been added.

https://github.com/BTCPrivate/BTCP-Rebase/pull/30