### PR TITLE
Fix VPNcoin (VASH) index

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -61,7 +61,7 @@ index | hexa       | symbol | coin
 30    | 0x8000001e | BURST  | Burst
 31    | 0x8000001f | MUE    | MonetaryUnit
 32    | 0x80000020 | ZOOM   | Zoom
-33    | 0x80000021 | VPN    | Vpncoin
+33    | 0x80000021 | VASH   | [Virtual Cash](http://www.bitnet.cc/) Also known as VPNcoin
 34    | 0x80000022 | CDN    | [Canada eCoin](https://github.com/Canada-eCoin/)
 35    | 0x80000023 | SDC    | ShadowCash
 36    | 0x80000024 | PKB    | [ParkByte](https://github.com/parkbyte/)
@@ -102,7 +102,7 @@ index | hexa       | symbol | coin
 71    | 0x80000047 | CMP    | [Compcoin](https://compcoin.com)
 72    | 0x80000048 | CRW    | [Crown](http://crown.tech/)
 73    | 0x80000049 | BELA   | [BelaCoin](http://belacoin.org)
-74    | 0x8000004a | VASH   | [Virtual Cash](http://www.bitnet.cc/) the new version of Vpncoin
+74    | 0x8000004a |        |
 75    | 0x8000004b | FJC    | [FujiCoin](http://www.fujicoin.org/)
 76    | 0x8000004c | MIX    | [MIX](https://www.mix-blockchain.org/)
 77    | 0x8000004d | XVG    | [Verge](https://github.com/vergecurrency/verge/)


### PR DESCRIPTION
VPNcoin changed their symbol few years ago to VASH however the
blockchain remained the same.

This commit corrects the name and removes the duplicate entry.