### PR TITLE
add Upub and Uprv

### DIFF
--- a/slip-0132.md
+++ b/slip-0132.md
@@ -36,6 +36,7 @@ Bitcoin                                   | `0x0295b43f` - `Ypub` | `0x0295b005`
 Bitcoin                                   | `0x02aa7ed3` - `Zpub` | `0x02aa7a99` - `Zprv` | P2WSH            | -           |
 Bitcoin Testnet                           | `0x043587cf` - `tpub` | `0x04358394` - `tprv` | P2PKH or P2SH    | m/44'/1'    |
 Bitcoin Testnet                           | `0x044a5262` - `upub` | `0x044a4e28` - `uprv` | P2WPKH in P2SH   | m/49'/1'    |
+Bitcoin Testnet                           | `0x024289ef` - `Upub` | `0x024285b5` - `Uprv` | P2WSH in P2SH    | -           |
 Bitcoin Testnet                           | `0x045f1cf6` - `vpub` | `0x045f18bc` - `vprv` | P2WPKH           | m/84'/1'    |
 Bitcoin Testnet                           | `0x02575483` - `Vpub` | `0x02575048` - `Vprv` | P2WSH            | -           |
 [Litecoin](https://litecoin.org/)         | `0x019da462` - `Ltub` | `0x019d9cfe` - `Ltpv` | P2PKH or P2SH    | m/44'/2'    |


### PR DESCRIPTION
I noticed that the SLIP does not have an entry for P2WSH in P2SH for TBTC. I'm adding the version bytes that we are using at Casa based upon the entry in SomberNight's draft BIP at https://github.com/SomberNight/bips/blob/bip-xpub-versionbytes-extension/bip-xpub-versionbytes-extension.mediawiki