### PR TITLE
[trivial] s/ravencon/ravencoin

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -34,7 +34,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | [Groestlcoin](https://groestlcoin.org/)    | `grs`   | `tgrs`  |           |
 | [Litecoin](https://litecoin.org/)          | `ltc`   | `tltc`  | `rltc`    |
 | [Namecoin](https://www.namecoin.org/)      | `nc`    | `tn`    | `ncrt`    |
-| [Ravencon](https://ravencoin.org/)         | `rc`    | `tr`    | `rcrt`    |
+| [Ravencoin](https://ravencoin.org/)         | `rc`    | `tr`    | `rcrt`    |
 | [Vertcoin](https://vertcoin.org/)          | `vtc`   | `tvtc`  |           |
 | [Viacoin](https://viacoin.org/)            | `via`   | `tvia`  |           |
 | [Zen Protocol](https://zenprotocol.com/)   | `zen`   | `tzn`   |           |

--- a/slip-0173.md
+++ b/slip-0173.md
@@ -34,7 +34,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | [Groestlcoin](https://groestlcoin.org/)    | `grs`   | `tgrs`  |           |
 | [Litecoin](https://litecoin.org/)          | `ltc`   | `tltc`  | `rltc`    |
 | [Namecoin](https://www.namecoin.org/)      | `nc`    | `tn`    | `ncrt`    |
-| [Ravencoin](https://ravencoin.org/)         | `rc`    | `tr`    | `rcrt`    |
+| [Ravencoin](https://ravencoin.org/)        | `rc`    | `tr`    | `rcrt`    |
 | [Vertcoin](https://vertcoin.org/)          | `vtc`   | `tvtc`  |           |
 | [Viacoin](https://viacoin.org/)            | `via`   | `tvia`  |           |
 | [Zen Protocol](https://zenprotocol.com/)   | `zen`   | `tzn`   |           |


### PR DESCRIPTION
Correct spelling of ravencoin