### PR TITLE
Add BIP-136 HRP's to SLIP-173

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -39,6 +39,12 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | [Viacoin](https://viacoin.org/)            | `via`   | `tvia`  |           |
 | [Zen Protocol](https://zenprotocol.com/)   | `zen`   | `tzn`   |           |
 
+These are the registered human-readable parts for usage in Bech32 encoding for other purposes:
+
+| Project / Standard                                                       | Registered Parts |
+| ------------------------------------------------------------------------ | ---------------- |
+| [TxRef](https://github.com/bitcoin/bips/blob/master/bip-0136.mediawiki) | `tx`, `txtest`   |
+
 ## Libraries
 
 * [Reference Implementations](https://github.com/sipa/bech32/tree/master/ref)


### PR DESCRIPTION
This adds the two HRP's that are used in BIP 136 to SLIP 173.

I have created a new section as they do not relate to witness programs.

Please merge once https://github.com/bitcoin/bips/pull/555 is merged.