### PR TITLE
Add Monacoin bech32 addresses

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -33,6 +33,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | [FujiCoin](http://www.fujicoin.org/)       | `fc`    | `tf`    | `fcrt`    |
 | [Groestlcoin](https://groestlcoin.org/)    | `grs`   | `tgrs`  |           |
 | [Litecoin](https://litecoin.org/)          | `ltc`   | `tltc`  | `rltc`    |
+| [Monacoin](https://monacoin.org/)          | `mona`  | `tmona` | `rmona`   |
 | [Namecoin](https://www.namecoin.org/)      | `nc`    | `tn`    | `ncrt`    |
 | [Ravencoin](https://ravencoin.org/)        | `rc`    | `tr`    | `rcrt`    |
 | [Vertcoin](https://vertcoin.org/)          | `vtc`   | `tvtc`  |           |


### PR DESCRIPTION
Monacoin currently uses the human readable part below.

mainnet `mona` https://github.com/monacoinproject/monacoin/blob/master-0.16/src/chainparams.cpp#L147
testnet `tmona` https://github.com/monacoinproject/monacoin/blob/master-0.16/src/chainparams.cpp#L256
regtest `rmona` https://github.com/monacoinproject/monacoin/blob/master-0.16/src/chainparams.cpp#L363