### PR TITLE
Add ndau coin ID

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -352,6 +352,7 @@ index | hexa       | symbol | coin
 13107 | 0x80003333 | BTY    | [BitYuan](https://www.bityuan.com)
 13108 | 0x80003334 | YCC    | [Yuan Chain Coin](https://www.yuan.org)
 15845 | 0x80003de5 | SDGO   | [SanDeGo](http://www.sandego.net)
+20036 | 0x80004e44 | NDAU   | [ndau](https://ndau.io/)
 22504 | 0x800057e8 | PWR    | [PWRcoin](https://github.com/Plainkoin/PWRcoin)
 31102 | 0x8000797e | ESN    | [EtherSocial Network](https://ethersocial.network)
 31337 | 0x80007a69 |        | [ThePower.io](https://thepower.io)


### PR DESCRIPTION
ndau is a new coin from oneiro.io (coin page at http://ndau.io) that was announced at TokenFest in September. 

We have a wallet app in private beta and will have a live mainnet in October.