### PR TITLE
SLIP-0044 Add Aquachain

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1104,6 +1104,7 @@ index | hexa       | symbol | coin
 5249354 | 0x8050194a | BHD    | [BitcoinHD](http://btchd.net/)
 5718350 | 0x8057414e | WAN    | [Wanchain](https://wanchain.org/)
 5741564 | 0x80579bfc | WAVES  | [Waves](https://wavesplatform.com/)
+61717561 | 0x83adbc39 | AQUA  | [Aquachain](https://aquachain.github.io/)
 91927009 | 0x857ab1e1 | kUSD   | [kUSD](https://kowala.tech)
 99999999 | 0x85f5e0ff | QKC   | [QuarkChain](https://www.quarkchain.io)
 


### PR DESCRIPTION
Aquachain (AQUA) is an alt-ether, pure proof-of-work, with scheduled maintenance hard forks. Current POW algorithm: `Argon2id`

Hex column was generated with `web3.toHex(0x80000000+chainid)` from the AQUA console

Aquachain links: [source code](https://gitlab.com/aquachain/aquachain ) | [website](https://aquachain.github.io)