### PR TITLE
Correct DASH symbol.

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -33,7 +33,7 @@ index | hexa       | symbol | coin
 2     | 0x80000002 | LTC    | [Litecoin](https://litecoin.org/)
 3     | 0x80000003 | DOGE   | [Dogecoin](https://github.com/dogecoin/dogecoin)
 4     | 0x80000004 | RDD    | Reddcoin
-5     | 0x80000005 | DSH    | [Dash](https://github.com/dashpay/dash) (ex Darkcoin)
+5     | 0x80000005 | DASH   | [Dash](https://github.com/dashpay/dash) (ex Darkcoin)
 6     | 0x80000006 | PPC    | [Peercoin](https://peercoin.net/)
 7     | 0x80000007 | NMC    | [Namecoin](http://namecoin.info/)
 8     | 0x80000008 | FTC    | [Feathercoin](https://www.feathercoin.com/)


### PR DESCRIPTION
Major majority of exchanges use `DASH` for the symbol: https://coinmarketcap.com/currencies/dash/#markets

Corrected to `DASH`.