### PR TITLE
Add TurtleCoin (TRTL) to SLIP-0044

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1048,6 +1048,7 @@ index | hexa       | symbol | coin
 1901  | 0x8000076d | CLC    | [Classica](https://github.com/classica/)
 1919  | 0x8000077f | VIPS   | [VIPSTARCOIN](https://www.vipstarcoin.jp/)
 1977  | 0x800007b9 | XMX    | [Xuma](http://www.xumacoin.org/)
+1984  | 0x800007c0 | TRTL   | [TurtleCoin](https://turtlecoin.lol/)
 1987  | 0x800007c3 | EGEM   | [EtherGem](https://egem.io)
 1989  | 0x800007c5 | HODL   | [HOdlcoin](https://hodlcoin.com/)
 1990  | 0x800007c6 | PHL    | [Placeholders](https://placeh.io/)


### PR DESCRIPTION
Add coin type for TurtleCoin.
We are implementing Ledger Nano S support for TurtleCoin and have a working prototype.