### PR TITLE
Add Blocknode (BND) to list

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1065,6 +1065,7 @@ index | hexa       | symbol | coin
 3552  | 0x80000de0 | DEO    | [Destocoin](https://desto.io)
 3564  | 0x80000dec | DST    | [DeStream](https://destream.io)
 2718  | 0x80000a9e | NAS    | [Nebulas](https://nebulas.io/)
+2941  | 0x80000b7d | BND    | [Blocknode](https://blocknode.tech)
 3276  | 0x80000ccc | CCC    | [CodeChain](https://codechain.io/)
 3377  | 0x80000d31 | ROI    | [ROIcoin](https://roi-coin.com/)
 4218  | 0x8000107a | IOTA   | [IOTA](https://www.iota.org/)


### PR DESCRIPTION
Add Blocknode to the list of supported BIP44 coins.