### PR TITLE
Release Type 118 (0x80000076) to ATOM for upcoming port of PIGGY to T…

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -146,7 +146,7 @@ index | hexa       | symbol | coin
 115   | 0x80000073 | ECN    | [Ecoin](https://www.ecoinsource.com)
 116   | 0x80000074 | DNR    | [Denarius](https://denarius.io)
 117   | 0x80000075 | PINK   | [Pinkcoin](http://getstarted.with.pink)
-118   | 0x80000076 | PIGGY  | [PiggyCoin](https://www.piggy-coin.com/)
+118   | 0x80000076 | ATOM   | Atom
 119   | 0x80000077 | PIVX   | [Pivx](https://github.com/PIVX-Project/PIVX)
 120   | 0x80000078 | FLASH  | [Flashcoin](https://flashcoin.io)
 121   | 0x80000079 | ZEN    | [Zencash](https://zensystem.io)


### PR DESCRIPTION
…endermint (Cosmos/Atom) node chain.

Cosmos team will also submit PR to Satoshilabs and assign appropriate URL for ATOM ticker.

PIGGY has no use of this Type presently "in the wild" whereas Cosmos/Atom team does.