### PR TITLE
Add City Coin (City Chain) to BIP44 slip

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1047,6 +1047,7 @@ index | hexa       | symbol | coin
 1856  | 0x80000743 | TES    | [Teslacoin](https://www.tesla-coin.com/)
 1901  | 0x8000076d | CLC    | [Classica](https://github.com/classica/)
 1919  | 0x8000077f | VIPS   | [VIPSTARCOIN](https://www.vipstarcoin.jp/)
+1926  | 0x80000786 | CITY   | [City Coin](https://city-chain.org/)
 1977  | 0x800007b9 | XMX    | [Xuma](http://www.xumacoin.org/)
 1984  | 0x800007c0 | TRTL   | [TurtleCoin](https://turtlecoin.lol/)
 1987  | 0x800007c3 | EGEM   | [EtherGem](https://egem.io)


### PR DESCRIPTION
- New blockchain named City Chain, using City Coin (CITY ticker).