### PR TITLE
Update slip-0044.md with NULS main chain ID

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1082,6 +1082,7 @@ index | hexa       | symbol | coin
 7777  | 0x80001e61 | BTV    | [Bitvote](https://www.bitvote.one)
 8339  | 0x80002093 | BTQ    | [BitcoinQuark](https://www.bitcoinquark.org)
 8888  | 0x800022b8 | SBTC   | [Super Bitcoin](https://www.superbtc.org)
+8964  | 0x80002304 | NULS   | [NULS](https://nuls.io)
 8999  | 0x80002327 | BTP    | [Bitcoin Pay](http://www.btceasypay.com)
 9797  | 0x80002645 | NRG    | [Energi](https://www.energi.world/)
 9888  | 0x800026a0 | BTF    | [Bitcoin Faith](http://bitcoinfaith.org)


### PR DESCRIPTION
NULS uses the secp256k1 curve and has a chain_id of 8964 for main net chain.

For the record, I am one of the core community developers of NULS.