### PR TITLE
slip-0044: Add aeternity cryptocurrency

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -485,7 +485,7 @@ index | hexa       | symbol | coin
 454   | 0x800001c6 |        |
 455   | 0x800001c7 |        |
 456   | 0x800001c8 |        |
-457   | 0x800001c9 |        |
+457   | 0x800001c9 | AE     | [æternity](https://aeternity.com)
 458   | 0x800001ca |        |
 459   | 0x800001cb |        |
 460   | 0x800001cc |        |


### PR DESCRIPTION
Derivation with this constant is implemented in [hd-wallet-js](https://github.com/aeternity/hd-wallet-js/blob/39d914cdcbf14649a3d4c64720e784b2e2598fc1/src/hd-wallet.js#L21) that used in [the Base app](https://github.com/aeternity/aepp-base) and [AirGap Wallet](https://github.com/airgap-it/airgap-coin-lib). Also, this derivation constant is used in our [app for Ledger Nano S](https://github.com/aeternity/ledger-app/blob/07bbd59f652292004789f914d8b8443f079bc5b2/src/utils.c#L94).