### PR TITLE
slip-044.md: Add Veil

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -264,7 +264,7 @@ index | hexa       | symbol | coin
 233   | 0x800000e9 | VAR    | [Varda](https://varda.io)
 234   | 0x800000ea | IOV    | [IOV](https://www.iov.one)
 235   | 0x800000eb | FIO    | [FIO](https://fio.foundation)
-236   | 0x800000ec | VEIL   | [Veil](https://www.veil-project.com)
+236   | 0x800000ec |        | 
 237   | 0x800000ed |        |
 238   | 0x800000ee | QRL    | [Quantum Resistant Ledger](https://www.theqrl.org/)
 239   | 0x800000ef |        |
@@ -726,7 +726,7 @@ index | hexa       | symbol | coin
 695   | 0x800002b7 |        |
 696   | 0x800002b8 |        |
 697   | 0x800002b9 |        |
-698   | 0x800002ba |        |
+698   | 0x800002ba | VEIL   | [Veil](https://www.veil-project.com)
 699   | 0x800002bb |        |
 700   | 0x800002bc |        |
 701   | 0x800002bd |        |

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -264,7 +264,7 @@ index | hexa       | symbol | coin
 233   | 0x800000e9 | VAR    | [Varda](https://varda.io)
 234   | 0x800000ea | IOV    | [IOV](https://www.iov.one)
 235   | 0x800000eb | FIO    | [FIO](https://fio.foundation)
-236   | 0x800000ec |        | 
+236   | 0x800000ec |        |
 237   | 0x800000ed |        |
 238   | 0x800000ee | QRL    | [Quantum Resistant Ledger](https://www.theqrl.org/)
 239   | 0x800000ef |        |

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -264,7 +264,7 @@ index | hexa       | symbol | coin
 233   | 0x800000e9 | VAR    | [Varda](https://varda.io)
 234   | 0x800000ea | IOV    | [IOV](https://www.iov.one)
 235   | 0x800000eb | FIO    | [FIO](https://fio.foundation)
-236   | 0x800000ec |        |
+236   | 0x800000ec | VEIL   | [Veil](https://www.veil-project.com)
 237   | 0x800000ed |        |
 238   | 0x800000ee | QRL    | [Quantum Resistant Ledger](https://www.theqrl.org/)
 239   | 0x800000ef |        |

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -548,7 +548,7 @@ index | hexa       | symbol | coin
 517   | 0x80000205 |        |
 518   | 0x80000206 | LET    | [Linkeye](https://www.linkeye.com/)
 519   | 0x80000207 |        |
-520   | 0x80000208 | BTCV   | [BitcoinVIP](https://www.bitvip.org/) 
+520   | 0x80000208 | BTCV   | [BitcoinVIP](https://www.bitvip.org/)
 521   | 0x80000209 |        |
 522   | 0x8000020a |        |
 523   | 0x8000020b |        |


### PR DESCRIPTION
Veil will launch on December 15th, 2018. It will support a full HD wallet for both Basecoin and Zerocoin.