### PR TITLE
Add Bytecoin

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -232,7 +232,7 @@ index | hexa       | symbol | coin
 201   | 0x800000c9 | BIFI   | [BitcoinFile](https://www.bitcoinfile.org)
 202   | 0x800000ca | UFO    | [Uniform Fiscal Object](https://ufobject.com)
 203   | 0x800000cb | CNMC   | [Cryptonodes](https://www.cryptonodes.ch)
-204   | 0x800000cc |        |
+204   | 0x800000cc | BCN    | [Bytecoin](http://bytecoin.org)
 205   | 0x800000cd | RIN    | [Ringo](http://dkwzjw.github.io/ringo/)
 206   | 0x800000ce | ATP    | [PlatON](https://www.platon.network)
 207   | 0x800000cf | EVT    | [everiToken](https://everiToken.io)


### PR DESCRIPTION
The coin exists since March 4, 2014.
We are top 40 at the [CoinMarketCap](https://coinmarketcap.com/currencies/bytecoin-bcn/).