### PR TITLE
[slip-0044] add url for binance chain

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -742,7 +742,7 @@ index | hexa       | symbol | coin
 711   | 0x800002c7 |        |
 712   | 0x800002c8 |        |
 713   | 0x800002c9 | KTS    | [Katallassos](https://katallassos.com)
-714   | 0x800002ca | BNB    | Binance
+714   | 0x800002ca | BNB    | [Binance](https://www.binance.org)
 715   | 0x800002cb |        |
 716   | 0x800002cc |        |
 717   | 0x800002cd |        |


### PR DESCRIPTION
We finally decide we will use www.binance.org for our binance chain DEX, a follow up of https://github.com/satoshilabs/slips/pull/424