### PR TITLE
[slip-0173] Add Unit-e address prefixes

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -40,6 +40,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | [Quantum Resistant Ledger](https://theqrl.org) | `qrl`   | `tqrl`  | `qrlrt`   |
 | [Ravencoin](https://ravencoin.org/)            | `rc`    | `tr`    | `rcrt`    |
 | [Susucoin](https://www.susukino.com/)          | `susu`  | `tutu`  | `ruru`    |
+| [Unit-e](https://dtr.org/unit-e/)              | `ue`    | `tue`   | `uert`    |
 | [Vertcoin](https://vertcoin.org/)              | `vtc`   | `tvtc`  |           |
 | [Viacoin](https://viacoin.org/)                | `via`   | `tvia`  |           |
 | [VIPSTARCOIN](https://www.vipstarcoin.jp/)     | `vips`  | `tvips` |           |


### PR DESCRIPTION
This adds BIP 0173 prefixes for [Unit-e](https://dtr.org/unit-e/) to SLIP 0173.

The proposed prefixes are `ue`, `tue`, and `uert`.