### PR TITLE
Add Energy Web

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -274,7 +274,7 @@ index | hexa       | symbol | coin
 243   | 0x800000f3 | SOV    | [Sovereign Coin](http://www.sovcore.org/)
 244   | 0x800000f4 | JCT    | [Jibital Coin](https://jibital.ir/)
 245   | 0x800000f5 | SLP    | [Simple Ledger Protocol](https://simpleledger.cash)
-246   | 0x800000f6 |        |
+246   | 0x800000f6 |        | [Energy Web](https://energyweb.org)
 247   | 0x800000f7 | UC     | [Ulord](http://ulord.one)
 248   | 0x800000f8 | CIVX   | [CivX](https://civxeconomy.com)
 249   | 0x800000f9 |        |


### PR DESCRIPTION
Currently implemented in a developer-only Ledger Nano S app. Eventually will be on the public facing Ledger Manager, and in other wallets.