### PR TITLE
SLIP 132: Mention multisignature script type for Yp and Zp prefixed keys

### DIFF
--- a/slip-0132.md
+++ b/slip-0132.md
@@ -36,8 +36,8 @@ Bitcoin                                   | `0x0295b43f` - `Ypub` | `0x0295b005`
 Bitcoin                                   | `0x02aa7ed3` - `Zpub` | `0x02aa7a99` - `Zprv` | Multi-signature P2WSH            | -           |
 Bitcoin Testnet                           | `0x043587cf` - `tpub` | `0x04358394` - `tprv` | P2PKH or P2SH                    | m/44'/1'    |
 Bitcoin Testnet                           | `0x044a5262` - `upub` | `0x044a4e28` - `uprv` | P2WPKH in P2SH                   | m/49'/1'    |
-Bitcoin Testnet                           | `0x024289ef` - `Upub` | `0x024285b5` - `Uprv` | Multi-signature P2WSH in P2SH    | -           |
 Bitcoin Testnet                           | `0x045f1cf6` - `vpub` | `0x045f18bc` - `vprv` | P2WPKH                           | m/84'/1'    |
+Bitcoin Testnet                           | `0x024289ef` - `Upub` | `0x024285b5` - `Uprv` | Multi-signature P2WSH in P2SH    | -           |
 Bitcoin Testnet                           | `0x02575483` - `Vpub` | `0x02575048` - `Vprv` | Multi-signature P2WSH            | -           |
 [Litecoin](https://litecoin.org/)         | `0x019da462` - `Ltub` | `0x019d9cfe` - `Ltpv` | P2PKH or P2SH                    | m/44'/2'    |
 Litecoin                                  | `0x01b26ef6` - `Mtub` | `0x01b26792` - `Mtpv` | P2WPKH in P2SH                   | m/49'/1'    |

--- a/slip-0132.md
+++ b/slip-0132.md
@@ -27,23 +27,23 @@ A final important motiviation for establishing a clearinghouse of HD version byt
 
 These are the registered HD version bytes for extended serialization of public and private keys.
 
-Coin                                      | Public Key            | Private Key           | Address Encoding | BIP 32 Path |
-------------------------------------------|-----------------------|-----------------------|------------------|-------------|
-[Bitcoin](https://bitcoin.org/)           | `0x0488b21e` - `xpub` | `0x0488ade4` - `xprv` | P2PKH or P2SH    | m/44'/0'    |
-Bitcoin                                   | `0x049d7cb2` - `ypub` | `0x049d7878` - `yprv` | P2WPKH in P2SH   | m/49'/0'    |
-Bitcoin                                   | `0x04b24746` - `zpub` | `0x04b2430c` - `zprv` | P2WPKH           | m/84'/0'    |
+Coin                                      | Public Key            | Private Key           | Address Encoding                 | BIP 32 Path |
+------------------------------------------|-----------------------|-----------------------|----------------------------------|-------------|
+[Bitcoin](https://bitcoin.org/)           | `0x0488b21e` - `xpub` | `0x0488ade4` - `xprv` | P2PKH or P2SH                    | m/44'/0'    |
+Bitcoin                                   | `0x049d7cb2` - `ypub` | `0x049d7878` - `yprv` | P2WPKH in P2SH                   | m/49'/0'    |
+Bitcoin                                   | `0x04b24746` - `zpub` | `0x04b2430c` - `zprv` | P2WPKH                           | m/84'/0'    |
 Bitcoin                                   | `0x0295b43f` - `Ypub` | `0x0295b005` - `Yprv` | Multi-signature P2WSH in P2SH    | -           |
 Bitcoin                                   | `0x02aa7ed3` - `Zpub` | `0x02aa7a99` - `Zprv` | Multi-signature P2WSH            | -           |
-Bitcoin Testnet                           | `0x043587cf` - `tpub` | `0x04358394` - `tprv` | P2PKH or P2SH    | m/44'/1'    |
-Bitcoin Testnet                           | `0x044a5262` - `upub` | `0x044a4e28` - `uprv` | P2WPKH in P2SH   | m/49'/1'    |
-Bitcoin Testnet                           | `0x024289ef` - `Upub` | `0x024285b5` - `Uprv` | P2WSH in P2SH    | -           |
-Bitcoin Testnet                           | `0x045f1cf6` - `vpub` | `0x045f18bc` - `vprv` | P2WPKH           | m/84'/1'    |
-Bitcoin Testnet                           | `0x02575483` - `Vpub` | `0x02575048` - `Vprv` | P2WSH            | -           |
-[Litecoin](https://litecoin.org/)         | `0x019da462` - `Ltub` | `0x019d9cfe` - `Ltpv` | P2PKH or P2SH    | m/44'/2'    |
-Litecoin                                  | `0x01b26ef6` - `Mtub` | `0x01b26792` - `Mtpv` | P2WPKH in P2SH   | m/49'/1'    |
-Litecoin Testnet                          | `0x0436f6e1` - `ttub` | `0x0436ef7d` - `ttpv` | P2PKH or P2SH    | m/44'/1'    |
-[Vertcoin](https://vertcoin.org/)         | `0x0488b21e` - `vtcp` | `0x0488ade4` - `vtcv` | P2PKH or P2SH    | m/44'/28'   |
-[Polis](https://polispay.org/)            | `0x03e25d7e` - `ppub` | `0x03e25945` - `pprv` | P2PKH            | m/44'/1997' |
+Bitcoin Testnet                           | `0x043587cf` - `tpub` | `0x04358394` - `tprv` | P2PKH or P2SH                    | m/44'/1'    |
+Bitcoin Testnet                           | `0x044a5262` - `upub` | `0x044a4e28` - `uprv` | P2WPKH in P2SH                   | m/49'/1'    |
+Bitcoin Testnet                           | `0x024289ef` - `Upub` | `0x024285b5` - `Uprv` | Multi-signature P2WSH in P2SH    | -           |
+Bitcoin Testnet                           | `0x045f1cf6` - `vpub` | `0x045f18bc` - `vprv` | P2WPKH                           | m/84'/1'    |
+Bitcoin Testnet                           | `0x02575483` - `Vpub` | `0x02575048` - `Vprv` | Multi-signature P2WSH            | -           |
+[Litecoin](https://litecoin.org/)         | `0x019da462` - `Ltub` | `0x019d9cfe` - `Ltpv` | P2PKH or P2SH                    | m/44'/2'    |
+Litecoin                                  | `0x01b26ef6` - `Mtub` | `0x01b26792` - `Mtpv` | P2WPKH in P2SH                   | m/49'/1'    |
+Litecoin Testnet                          | `0x0436f6e1` - `ttub` | `0x0436ef7d` - `ttpv` | P2PKH or P2SH                    | m/44'/1'    |
+[Vertcoin](https://vertcoin.org/)         | `0x0488b21e` - `vtcp` | `0x0488ade4` - `vtcv` | P2PKH or P2SH                    | m/44'/28'   |
+[Polis](https://polispay.org/)            | `0x03e25d7e` - `ppub` | `0x03e25945` - `pprv` | P2PKH                            | m/44'/1997' |
 
 ## Bitcoin Test Vectors
 

--- a/slip-0132.md
+++ b/slip-0132.md
@@ -32,8 +32,8 @@ Coin                                      | Public Key            | Private Key 
 [Bitcoin](https://bitcoin.org/)           | `0x0488b21e` - `xpub` | `0x0488ade4` - `xprv` | P2PKH or P2SH    | m/44'/0'    |
 Bitcoin                                   | `0x049d7cb2` - `ypub` | `0x049d7878` - `yprv` | P2WPKH in P2SH   | m/49'/0'    |
 Bitcoin                                   | `0x04b24746` - `zpub` | `0x04b2430c` - `zprv` | P2WPKH           | m/84'/0'    |
-Bitcoin                                   | `0x0295b43f` - `Ypub` | `0x0295b005` - `Yprv` | P2WSH in P2SH    | -           |
-Bitcoin                                   | `0x02aa7ed3` - `Zpub` | `0x02aa7a99` - `Zprv` | P2WSH            | -           |
+Bitcoin                                   | `0x0295b43f` - `Ypub` | `0x0295b005` - `Yprv` | Multi-signature P2WSH in P2SH    | -           |
+Bitcoin                                   | `0x02aa7ed3` - `Zpub` | `0x02aa7a99` - `Zprv` | Multi-signature P2WSH            | -           |
 Bitcoin Testnet                           | `0x043587cf` - `tpub` | `0x04358394` - `tprv` | P2PKH or P2SH    | m/44'/1'    |
 Bitcoin Testnet                           | `0x044a5262` - `upub` | `0x044a4e28` - `uprv` | P2WPKH in P2SH   | m/49'/1'    |
 Bitcoin Testnet                           | `0x024289ef` - `Upub` | `0x024285b5` - `Uprv` | P2WSH in P2SH    | -           |


### PR DESCRIPTION
Late follow up, but hope this is an acceptable fix for https://github.com/satoshilabs/slips/issues/315

Really don't like handling these as multisig without being able to refer to the spec.

