### PR TITLE
slip-0173: add handshake

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -33,6 +33,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | [DigiByte](https://www.digibyte.io/)           | `dgb`   | `dgbt`  | `dgbrt`   |
 | [FujiCoin](http://www.fujicoin.org/)           | `fc`    | `tf`    | `fcrt`    |
 | [Groestlcoin](https://groestlcoin.org/)        | `grs`   | `tgrs`  | `grsrt`   |
+| [Handshake](https://handshake.org/)            | `hs`    | `ts`    | `rs`      |
 | [Litecoin](https://litecoin.org/)              | `ltc`   | `tltc`  | `rltc`    |
 | [Monacoin](https://monacoin.org/)              | `mona`  | `tmona` | `rmona`   |
 | [Myriad](https://myriadcoin.org/)              | `my`    | `tm`    |           |


### PR DESCRIPTION
This adds the hrps for Handshake - https://handshake.org

Their definitions:
- main - https://github.com/handshake-org/hsd/blob/6147ac837eaabb3a2e9c34530e1a8bd1b29d9e34/lib/protocol/networks.js#L456

- testnet - https://github.com/handshake-org/hsd/blob/6147ac837eaabb3a2e9c34530e1a8bd1b29d9e34/lib/protocol/networks.js#L682

- regtest - https://github.com/handshake-org/hsd/blob/6147ac837eaabb3a2e9c34530e1a8bd1b29d9e34/lib/protocol/networks.js#L830