### PR TITLE
add coin type of shitcoin

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -303,7 +303,7 @@ index | hexa       | symbol | coin
 272   | 0x80000110 | IPC    | [IPChain](https://www.ipcchain.org)
 273   | 0x80000111 | DMTC   | [Dominantchain](https://dominantchain.com/)
 274   | 0x80000112 | OGC    | [Onegram](https://onegram.org/)
-275   | 0x80000113 |        |
+275   | 0x80000113 | SHIT   | [Shitcoin](https://shitcoin.org)
 276   | 0x80000114 |        |
 277   | 0x80000115 |        |
 278   | 0x80000116 |        |
@@ -438,7 +438,7 @@ index | hexa       | symbol | coin
 407   | 0x80000197 |        |
 408   | 0x80000198 |        |
 409   | 0x80000199 |        |
-410   | 0x8000019a | SHIT   | [Shitcoin](https://shitcoin.org)
+410   | 0x8000019a |        |
 411   | 0x8000019b |        |
 412   | 0x8000019c | AIN    | [AIN](https://www.ainetwork.ai)
 413   | 0x8000019d |        |

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -438,7 +438,7 @@ index | hexa       | symbol | coin
 407   | 0x80000197 |        |
 408   | 0x80000198 |        |
 409   | 0x80000199 |        |
-410   | 0x8000019a |        |
+410   | 0x8000019a | SHIT   | [Shitcoin](https://shitcoin.org)
 411   | 0x8000019b |        |
 412   | 0x8000019c | AIN    | [AIN](https://www.ainetwork.ai)
 413   | 0x8000019d |        |


### PR DESCRIPTION
A new PoW coin launched 2019, Shitcoin needs coin type of slip44.