### PR TITLE
slip-0044: add Factom ID as registered coin type 

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1138,7 +1138,6 @@ index | hexa       | symbol | coin
 99999999 | 0x85f5e0ff | QKC    | [QuarkChain](https://www.quarkchain.io)
 143165576 | 0x88888888 | FCTID  | [Factom ID](https://github.com/FactomProject)
 
-
 Coin types will be added only if there is a wallet implementing BIP-0044 for desired coin.
 
 ## Libraries

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1136,6 +1136,8 @@ index | hexa       | symbol | coin
 91927009 | 0x857ab1e1 | kUSD   | [kUSD](https://kowala.tech)
 99999998 | 0x85f5e0fe | FLUID  | [Fluid Chains](https://www.fluidchains.com)
 99999999 | 0x85f5e0ff | QKC    | [QuarkChain](https://www.quarkchain.io)
+143165576 | 0x88888888 | FCTID  | [Factom ID](https://github.com/FactomProject)
+
 
 Coin types will be added only if there is a wallet implementing BIP-0044 for desired coin.
 


### PR DESCRIPTION
https://support.ledger.com/hc/en-us/articles/360011611294-Factom-FCT-
https://github.com/MyFactomWallet/ledger-app-factom/blob/048cd68bdae7d9f7dd87d574d6cab9058e6da064/src/main.c#L62
https://github.com/FactomProject/factom/blob/56540a80c9048c0fa5a4228ad93e04389cf622f3/identityKeys.go#L154

This is in the process of being released for the Factom CLI wallet.  This constant is also most of the way through (if not completely through) the Ledger wallet audit/approval process.