### PR TITLE
slip-0044: Add Factom ID as registered coin type

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -309,7 +309,7 @@ index | hexa       | symbol | coin
 278   | 0x80000116 | BOLI   | [Bolivarcoin](https://bolis.info)
 279   | 0x80000117 | RIL    | [Rilcoin](https://www.rilcoincrypto.org)
 280   | 0x80000118 | HTR    | [Hathor Network](https://hathor.network/)
-281   | 0x80000119 |        |
+281   | 0x80000119 | FCTID  | [Factom ID](https://github.com/FactomProject)
 282   | 0x8000011a |        |
 283   | 0x8000011b |        |
 284   | 0x8000011c |        |


### PR DESCRIPTION
earlier pull request was closed because this is from a new source branch.

https://github.com/satoshilabs/slips/pull/557

https://support.ledger.com/hc/en-us/articles/360011611294-Factom-FCT-
https://github.com/MyFactomWallet/ledger-app-factom/blob/048cd68bdae7d9f7dd87d574d6cab9058e6da064/src/main.c#L62
https://github.com/FactomProject/factom/blob/56540a80c9048c0fa5a4228ad93e04389cf622f3/identityKeys.go#L154

This is in the process of being released for the Factom CLI wallet. This constant is also most of the way through (if not completely through) the Ledger wallet audit/approval process.

The pending constant is 143165576 | 0x88888888 but we will need to scramble to change it before release.