### PR TITLE
Register coin type 283 for Algorand

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -311,7 +311,7 @@ index | hexa       | symbol | coin
 280   | 0x80000118 | HTR    | [Hathor Network](https://hathor.network/)
 281   | 0x80000119 | FCTID  | [Factom ID](https://github.com/FactomProject)
 282   | 0x8000011a | BRAVO  | [BRAVO](https://bravocoin.com/)
-283   | 0x8000011b |        |
+283   | 0x8000011b | ALGO   | [Algorand](https://www.algorand.com/)
 284   | 0x8000011c |        |
 285   | 0x8000011d |        |
 286   | 0x8000011e |        |


### PR DESCRIPTION
I'm writing wallet software for the Algorand cryptocurrency that supports BIP-44-based key derivation, and would like to register a coin type for doing so.