### PR TITLE
Add Dapscoin to the BIP-44 Document

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -386,7 +386,7 @@ index | hexa       | symbol | coin
 355   | 0x80000163 | AEON   | [Aeon](https://www.aeon.cash/)
 356   | 0x80000164 | RES    | [Resistance](https://www.resistance.io)
 357   | 0x80000165 | AYA    | [Aryacoin](https://aryacoin.io/)
-358   | 0x80000166 |        |
+358   | 0x80000166 | DAPS   | [Dapscoin](https://officialdapscoin.com)
 359   | 0x80000167 |        |
 360   | 0x80000168 | VSYS   | [V Systems](https://www.v.systems/)
 361   | 0x80000169 |        |


### PR DESCRIPTION
This pull request makes the following changes to the BIP-44 Document

- Add Dapscoin to spot 358 on the BIP-44 Document (the next available spot) 
- Add Dapscoin URL [https://officialdapscoin.com]

This derivation is in use on the Dapscoin Beta Mobile Wallet's on both Android and iOS. 