### PR TITLE
Add CasinoCoin (CSC) to next available space.md

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -387,7 +387,7 @@ index | hexa       | symbol | coin
 356   | 0x80000164 | RES    | [Resistance](https://www.resistance.io)
 357   | 0x80000165 | AYA    | [Aryacoin](https://aryacoin.io/)
 358   | 0x80000166 |        |
-359   | 0x80000167 |        |
+359   | 0x80000167 | CSC    | [CasinoCoin](https://casinocoin.org)
 360   | 0x80000168 | VSYS   | [V Systems](https://www.v.systems/)
 361   | 0x80000169 |        |
 362   | 0x8000016a |        |


### PR DESCRIPTION
This change proposes adding CasinoCoin (CSC) to the next available space (#359 after allowing for existing open pull requests in the queue).
Project website is www.casinocoin.org