### PR TITLE
slip-0044: add MCASH

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1064,6 +1064,7 @@ index | hexa       | symbol | coin
 2018  | 0x800007e2 | EOSC   | [EOSClassic](https://eos-classic.io/)
 2019  | 0x800007e3 | GBT    | [GoldBean Token](http://www.adfunds.org/)
 2020  | 0x800007e4 | PKC    | [PKC](https://www.pkc.ink/)
+2048  | 0x80000800 | MCASH  | [MCashChain](https://mcash.network/)
 2049  | 0x80000801 | TRUE   | [TrueChain](https://www.truechain.pro/)
 2112  | 0x80000840 | IoTE   | [IoTE](https://www.iote.one/)
 2221  | 0x800008ad | ASK    | [ASK](https://permission.io/)


### PR DESCRIPTION
Add coin type for MCASH.

Please add coin type 2048

We have been using this coin_type in all of our products:
- Ledger App: we have deployed new [MCASH](https://github.com/MidasCore/ledger-app-mcash) native coin to many Ledger users 
- McashLight - web wallet [(Chrome/Brave extension)](https://chrome.google.com/webstore/detail/mcashlight/loiopaejobjggipodncmajcmdolegdan)
- Midas Wallet - [Ios App](https://apps.apple.com/us/app/midas-protocol-crypto-wallet/id1436698193)/[Android App](https://play.google.com/store/apps/details?id=com.midasprotocol.wallet.android) wallet: 