### PR TITLE
SLIP-044: Correct the official symbol of ndau to XND

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1114,7 +1114,7 @@ index | hexa       | symbol | coin
 19165 | 0x80004add | SAFE   | [Safecoin](https://www.safecoin.org)
 19167 | 0x80004adf | ZEL    | [ZelCash](https://www.zel.cash)
 19169 | 0x80004ae1 | RITO   | [Ritocoin](https://www.ritocoin.org)
-20036 | 0x80004e44 | NDAU   | [ndau](https://ndau.io/)
+20036 | 0x80004e44 | XND    | [ndau](https://ndau.io/)
 22504 | 0x800057e8 | PWR    | [PWRcoin](https://github.com/Plainkoin/PWRcoin)
 25252 | 0x800062a4 | BELL   | [Bellcoin](https://bellcoin.web4u.jp/)
 25718 | 0x80006476 | CHX    | [Own](https://wallet.weown.com)


### PR DESCRIPTION
The official symbol for ndau is XND but when we originally submitted this we thought it would be NDAU. This PR fixes that.