### PR TITLE
Assign bip-044 number to Skycoin

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1096,6 +1096,7 @@ index | hexa       | symbol | coin
 6688  | 0x80001a20 | SAFE   | [SAFE](http://www.anwang.com/)
 6969  | 0x80001b39 | ROGER  | [TheHolyrogerCoin](https://github.com/TheHolyRoger/TheHolyRogerCoin)
 7777  | 0x80001e61 | BTV    | [Bitvote](https://www.bitvote.one)
+8000  | 0x80001f40 | SKY    | [Skycoin](https://www.skycoin.net)
 8339  | 0x80002093 | BTQ    | [BitcoinQuark](https://www.bitcoinquark.org)
 8888  | 0x800022b8 | SBTC   | [Super Bitcoin](https://www.superbtc.org)
 8964  | 0x80002304 | NULS   | [NULS](https://nuls.io)


### PR DESCRIPTION
BIP44 wallet support added to Skycoin:
https://github.com/skycoin/skycoin/pull/2443

Underlying library implementation (go):
https://github.com/skycoin/skycoin/tree/develop/src/cipher/bip44