### PR TITLE
SLIP-0077: Correct ECDH pseudo-code

### DIFF
--- a/slip-0077.md
+++ b/slip-0077.md
@@ -51,7 +51,7 @@ master_blinding_key := node[32:64]
 The shared nonce is derived using ECDH and double-SHA256 of the compressed shared public key:
 
 ```
-shared := secp256k1_multiply(blinding_private_key, sender_public_key, compressed=True)
+shared := secp256k1_ecdh(sender_public_key, blinding_private_key)
 nonce := SHA256(SHA256(shared))
 ```
 


### PR DESCRIPTION
`secp256k1_multiply` doesn't exist. `secp256k1_ecdh` is used to do ECDH and there is no compression flag present: https://github.com/bitcoin-core/secp256k1/blob/c8fbc3c397b547bc64435a9bffb8f989cd23aba0/include/secp256k1_ecdh.h#L42