### PR TITLE
slip-0023: Create SLIP-0023.

### DIFF
--- a/slip-0023.md
+++ b/slip-0023.md
@@ -19,7 +19,7 @@ Cryptocurrency wallets generally work by combining a [BIP-0039](https://github.c
 
 Cardano hierarchical deterministic wallets use an extended private key which requires them to implement a custom adaptation of the BIP-0032 child key derivation scheme. The Cardano wallets currently in existence implement several mutually incompatible schemes for the derivation of the master node from a BIP-0039 mnemonic and passphrase. Unfortunately all of these derivation schemes fail to separate the derivation of the seed from the derivation of the key tree, making it impossible to integrate them with new seed derivation schemes. This specification aims to rectify this by defining a new scheme for the derivation of the master node from a seed. The new scheme is primarily intended for use with SLIP-0039 Shamir's Secret-Sharing for Mnemonic Codes.
 
-## Universal master node derivation
+## Cardano universal master node derivation
 
 This scheme adapts the master node derivation used in BIP-0032 and SLIP-0010 by defining a new curve name "ed25519 cardano seed" for the Ed25519 curve with the Cardano deterministic key hierarchy. The curve name is used as salt in BIP-0032 and SLIP-0010 when deriving the master node from the seed. This is necessary to ensure proper domain separation between different elliptic curves or different types of key hierarchies. The root extended private key (*k*<sub>L</sub>,&nbsp;*k*<sub>R</sub>) is computed by taking the SHA-512 hash of the root private key *I*<sub>L</sub>, modifying certain bits to make it a valid EdDSA key and clearing the third highest bit of *k*<sub>L</sub> to ensure compatibility with Cardano child key derivation.
 
@@ -30,9 +30,9 @@ This scheme adapts the master node derivation used in BIP-0032 and SLIP-0010 by 
 5. Modify *k* by assigning *k*[0] := *k*[0] & 0xf8 and *k*[31] := (*k*[31] & 0x1f) | 0x40.
 6. Interpret *k*[0:32] as a 256-bit integer *k*<sub>L</sub> in little-endian byte order. Let *k*<sub>R</sub> := *k*[32:64] and use (*k*<sub>L</sub>,&nbsp;*k*<sub>R</sub>) as the root extended private key and *c* := *I*<sub>R</sub> as the root chain code.
 
-## Icarus master node derivation
+## Cardano Icarus master node derivation
 
-The Icarus master node derivation scheme is commonly used with BIP-0039. Since there does not exist any specification of this scheme, its description is included below for completeness.
+The Icarus master node derivation scheme, aka V2 derivation scheme, is commonly used with BIP-0039 in Cardano wallets. Since there does not exist any specification of this scheme, its description is included below for completeness.
 
 1. Let *M* be a BIP-0039 mnemonic and *P* the passphrase entered by the user.
 2. Determine the initial entropy *E* that was used to generate *M*.
@@ -46,9 +46,9 @@ The derivation of child keys in the Cardano deterministic key hierarchy is speci
 
 ## Compliance
 
-Implementations which use SLIP-0039 as the source of the master secret MUST derive the master node for the Cardano deterministic key hierarchy using the Universal master node derivation scheme as specified above.
+Implementations which use SLIP-0039 as the source of the master secret MUST derive the master node for the Cardano deterministic key hierarchy using the Cardano universal master node derivation scheme as specified [above](#cardano-universal-master-node-derivation).
 
-Implementations which use BIP-0039 as the source of the master secret SHOULD derive the master node for the Cardano deterministic key hierarchy using the Icarus master node derivation scheme to maintain compatibility with existing wallets.
+Implementations which use BIP-0039 as the source of the master secret SHOULD derive the master node for the Cardano deterministic key hierarchy using the Cardano Icarus master node derivation scheme to maintain compatibility with existing wallets.
 
 ## Test vectors
 

--- a/slip-0023.md
+++ b/slip-0023.md
@@ -46,9 +46,9 @@ The derivation of child keys in the Cardano deterministic key hierarchy is speci
 
 ## Compliance
 
-Implementations which use SLIP-0039 as the source of the master secret MUST derive the master node for the Cardano deterministic key hierarchy using the Cardano universal master node derivation scheme as specified [above](#cardano-universal-master-node-derivation).
+When SLIP-0039 is used as the source of the master secret the master node for the Cardano deterministic key hierarchy MUST be derived using the Cardano universal master node derivation scheme as specified [above](#cardano-universal-master-node-derivation).
 
-Implementations which use BIP-0039 as the source of the master secret SHOULD derive the master node for the Cardano deterministic key hierarchy using the Cardano Icarus master node derivation scheme to maintain compatibility with existing wallets.
+When BIP-0039 is used as the source of the master secret the master node for the Cardano deterministic key hierarchy SHOULD be derived using the Cardano Icarus master node derivation scheme to maintain compatibility with existing wallets.
 
 ## Test vectors
 

--- a/slip-0023.md
+++ b/slip-0023.md
@@ -1,0 +1,63 @@
+# SLIP-0023 : Cardano HD master node derivation from a master seed
+
+```
+Number:  SLIP-0023
+Title:   Cardano HD master node derivation from a master seed
+Type:    Standard
+Status:  Draft
+Authors: Andrew R. Kozlik <andrew.kozlik@satoshilabs.com>
+Created: 2019-07-24
+```
+
+## Abstract
+
+This specification describes how to derive the master node, aka root node, of the key tree in Cardano hierarchical deterministic wallets.
+
+## Motivation
+
+Cryptocurrency wallets generally work by combining a [BIP-0039](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) mnemonic or a set of [SLIP-0039](https://github.com/satoshilabs/slips/blob/master/slip-0039.md) mnemonics with a user-entered passphrase to generate a master seed. This master seed is then used to derive a hierarchy of cryptographic keys as defined in [BIP-0032](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) and [SLIP-0010](https://github.com/satoshilabs/slips/blob/master/slip-0010.md).
+
+Cardano hierarchical deterministic wallets use an extended private key which requires them to implement a custom adaptation of the BIP-0032 child key derivation scheme. The Cardano wallets currently in existence implement several mutually incompatible schemes for the derivation of the master node from a BIP-0039 mnemonic and passphrase. Unfortunately all of these derivation schemes fail to separate the derivation of the seed from the derivation of the key tree, making it impossible to integrate them with new seed derivation schemes. This specification aims to rectify this by defining a new scheme for the derivation of the master node from a seed. The new scheme is primarily intended for use with SLIP-0039 Shamir's Secret-Sharing for Mnemonic Codes.
+
+## Universal master node derivation
+
+This scheme adapts the master node derivation used in BIP-0032 and SLIP-0010 by defining a new curve name "ed25519 cardano seed" for the Ed25519 curve with the Cardano deterministic key hierarchy. The curve name is used as salt in BIP-0032 and SLIP-0010 when deriving the master node from the seed. This is necessary to ensure proper domain separation between different elliptic curves or different types of key hierarchies. The root extended private key (*k*<sub>L</sub>,&nbsp;*k*<sub>R</sub>) is computed by taking the SHA-512 hash of the root private key *I*<sub>L</sub>, modifying certain bits to make it a valid EdDSA key and clearing the third highest bit of *k*<sub>L</sub> to ensure compatibility with Cardano child key derivation.
+
+1. Let *S* be a seed byte sequence such as the master secret from SLIP-0039.
+2. Calculate *I* := HMAC-SHA512(Key = "ed25519 cardano seed", Data = *S*).
+3. Split *I* into two 32-byte sequences, *I*<sub>L</sub> := *I*[0:32] and *I*<sub>R</sub> := *I*[32:64].
+4. Let *k* := SHA-512(*I*<sub>L</sub>).
+5. Modify *k* by assigning *k*[0] := *k*[0] & 0xf8 and *k*[31] := (*k*[31] & 0x1f) | 0x40.
+6. Interpret *k*[0:32] as a 256-bit integer *k*<sub>L</sub> in little-endian byte order. Let *k*<sub>R</sub> := *k*[32:64] and use (*k*<sub>L</sub>,&nbsp;*k*<sub>R</sub>) as the root extended private key and *c* := *I*<sub>R</sub> as the root chain code.
+
+## Icarus master node derivation
+
+The Icarus master node derivation scheme is commonly used with BIP-0039. Since there does not exist any specification of this scheme, its description is included below for completeness.
+
+1. Let *M* be a BIP-0039 mnemonic and *P* the passphrase entered by the user.
+2. Determine the initial entropy *E* that was used to generate *M*.
+3. Compute *S* := PBKDF2-HMAC-SHA512(password = *P*, salt = *E*, iterations = 4096, dkLen = 96).
+4. Modify *S* by assigning *S*[0] := *S*[0] & 0xf8 and *S*[31] := (*S*[31] & 0x1f) | 0x40.
+5. Interpret *S*[0:32] as a 256-bit integer *k*<sub>L</sub> in little-endian byte order. Let *k*<sub>R</sub> := *S*[32:64] and use (*k*<sub>L</sub>,&nbsp;*k*<sub>R</sub>) as the root extended private key and *c* := *S*[64:96] as the root chain code.
+
+## Child key derivation
+
+The derivation of child keys in the Cardano deterministic key hierarchy is specified in [BIP32-Ed25519](https://cardanolaunch.com/assets/Ed25519_BIP.pdf).
+
+## Compliance
+
+Implementations which use SLIP-0039 as the source of the master secret MUST derive the master node for the Cardano deterministic key hierarchy using the Universal master node derivation scheme as specified above.
+
+Implementations which use BIP-0039 as the source of the master secret SHOULD derive the master node for the Cardano deterministic key hierarchy using the Icarus master node derivation scheme to maintain compatibility with existing wallets.
+
+## Test vectors
+
+TODO
+
+## References
+
+* [BIP-0032](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki): Hierarchical Deterministic Wallets
+* [SLIP-0010](https://github.com/satoshilabs/slips/blob/master/slip-0010.md): Universal private key derivation from master private key
+* [BIP-0039](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki): Mnemonic code for generating deterministic keys
+* [SLIP-0039](https://github.com/satoshilabs/slips/blob/master/slip-0039.md): Shamir's Secret-Sharing for Mnemonic Codes
+* D. Khovratovich and J. Law: [BIP32-Ed25519 Hierarchical Deterministic Keys over a Non-linear Keyspace](https://cardanolaunch.com/assets/Ed25519_BIP.pdf)

--- a/slip-0023.md
+++ b/slip-0023.md
@@ -58,10 +58,11 @@ In the following test vectors the values of *S*, *k*<sub>R</sub>, *A* and *c* ar
 
 Let the seed be *S* = "578d685d20b602683dc5171df411d3e2".
 
-Note that *S* is the master secret obtained from the following three SLIP-0039 share mnemonics with the passphrase "TREZOR":<br/>
-"extra extend academic bishop cricket bundle tofu goat apart victim enlarge program behavior permit course armed jerky faint language modern",<br/>
-"extra extend academic acne away best indicate impact square oasis prospect painting voting guest either argue username racism enemy eclipse",<br/>
-"extra extend academic arcade born dive legal hush gross briefing talent drug much home firefly toxic analysis idea umbrella slice".
+Note that *S* is the master secret obtained from the following three SLIP-0039 share mnemonics with the passphrase "TREZOR":
+
+* "extra extend academic bishop cricket bundle tofu goat apart victim enlarge program behavior permit course armed jerky faint language modern",
+* "extra extend academic acne away best indicate impact square oasis prospect painting voting guest either argue username racism enemy eclipse",
+* "extra extend academic arcade born dive legal hush gross briefing talent drug much home firefly toxic analysis idea umbrella slice".
 
 The root extended private keys is:<br/>
 *k*<sub>L</sub> = 38096432269777187972282727382530464140043628323029465813805073381215192153792<br/>
@@ -86,9 +87,10 @@ Ae2tdPwUPEZGXmSbda1kBNfyhRQGRcQxJFdk7mhWZXAGnapyejv2b2U3aRb
 
 Let the seed be *S* = "a055b781aac0c9dc1bfb7d803bc8ffd5d4392e506db2e4a5a93f0aba958c5be7".
 
-Note that this is the master secret obtained from the two SLIP-0039 share mnemonics with the passphrase "TREZOR":<br/>
-"hobo romp academic axis august founder knife legal recover alien expect emphasis loan kitchen involve teacher capture rebuild trial numb spider forward ladle lying voter typical security quantity hawk legs idle leaves gasoline",<br/>
-"hobo romp academic agency ancestor industry argue sister scene midst graduate profile numb paid headset airport daisy flame express scene usual welcome quick silent downtown oral critical step remove says rhythm venture aunt".
+Note that this is the master secret obtained from the two SLIP-0039 share mnemonics with the passphrase "TREZOR":
+
+* "hobo romp academic axis august founder knife legal recover alien expect emphasis loan kitchen involve teacher capture rebuild trial numb spider forward ladle lying voter typical security quantity hawk legs idle leaves gasoline",
+* "hobo romp academic agency ancestor industry argue sister scene midst graduate profile numb paid headset airport daisy flame express scene usual welcome quick silent downtown oral critical step remove says rhythm venture aunt".
 
 The extended private keys is:<br/>
 *k*<sub>L</sub> =

--- a/slip-0023.md
+++ b/slip-0023.md
@@ -52,7 +52,64 @@ Implementations which use BIP-0039 as the source of the master secret SHOULD der
 
 ## Test vectors
 
-TODO
+In the following test vectors the values of *S*, *k*<sub>R</sub>, *A* and *c* are each encoded as a string containing two hexadecimal digits for each byte. The value of *k*<sub>L</sub> is encoded as an integer in base 10.
+
+### Test vector 1 for Cardano universal master node derivation (128 bits)
+
+Let the seed be *S* = "578d685d20b602683dc5171df411d3e2".
+
+Note that *S* is the master secret obtained from the following three SLIP-0039 share mnemonics with the passphrase "TREZOR":<br/>
+"extra extend academic bishop cricket bundle tofu goat apart victim enlarge program behavior permit course armed jerky faint language modern",<br/>
+"extra extend academic acne away best indicate impact square oasis prospect painting voting guest either argue username racism enemy eclipse",<br/>
+"extra extend academic arcade born dive legal hush gross briefing talent drug much home firefly toxic analysis idea umbrella slice".
+
+The root extended private keys is:<br/>
+*k*<sub>L</sub> = 38096432269777187972282727382530464140043628323029465813805073381215192153792<br/>
+*k*<sub>R</sub> = "4064253ffefc4127489bce1b825a47329010c5afb4d21154ef949ef786204405"
+
+The root public key is:<br/>
+*A* = "83e3ecaf57f90f022c45e10d1b8cb78499c30819515ad9a81ad82139fdb12a90"
+
+The root chain code is:<br/>
+*c* = "22c12755afdd192742613b3062069390743ea232bc1b366c8f41e37292af9305"
+
+The address for the derivation path 44'/1815'/0'/0/0 is:<br/>
+Ae2tdPwUPEYxF9NAMNdd3v2LZoMeWp7gCZiDb6bZzFQeeVASzoP7HC4V9s6
+
+The address for the derivation path 44'/1815'/0'/0/1 is:<br/>
+Ae2tdPwUPEZ1TjYcvfkWAbiHtGVxv4byEHHZoSyQXjPJ362DifCe1ykgqgy
+
+The address for the derivation path 44'/1815'/0'/0/2 is:<br/>
+Ae2tdPwUPEZGXmSbda1kBNfyhRQGRcQxJFdk7mhWZXAGnapyejv2b2U3aRb
+
+### Test vector 2 for Cardano universal master node derivation (256 bits)
+
+Let the seed be *S* = "a055b781aac0c9dc1bfb7d803bc8ffd5d4392e506db2e4a5a93f0aba958c5be7".
+
+Note that this is the master secret obtained from the two SLIP-0039 share mnemonics with the passphrase "TREZOR":<br/>
+"hobo romp academic axis august founder knife legal recover alien expect emphasis loan kitchen involve teacher capture rebuild trial numb spider forward ladle lying voter typical security quantity hawk legs idle leaves gasoline",<br/>
+"hobo romp academic agency ancestor industry argue sister scene midst graduate profile numb paid headset airport daisy flame express scene usual welcome quick silent downtown oral critical step remove says rhythm venture aunt".
+
+The extended private keys is:<br/>
+*k*<sub>L</sub> =
+35870817594148037193235249761081259065186522922583196642112477624627719791504
+<br/>
+*k*<sub>R</sub> = "f9d99bf3cd9c7e12663e8646afa40cb3aecf15d91f2abc15d21056c6bccb3414"
+
+The root public key is:<br/>
+*A* = "eea170f0ef97b59d22907cb429888029721ed67d3e7a1b56b81731086ab7db64"
+
+The root chain code is:<br/>
+*c* = "04f1de750b62725fcc1ae1b93ca4063acb53c486b959cadaa100ebd7828e5460"
+
+The address for the derivation path 44'/1815'/0'/0/0 is:<br/>
+Ae2tdPwUPEYyDD1C2FbVJFAE3FuAxLspfMYt29TJ1urnSKr57cVhEcioSCC
+
+The address for the derivation path 44'/1815'/0'/0/1 is:<br/>
+Ae2tdPwUPEZHJGtyz47F6wD7qAegt1JNRJWuiE36QLvFzeqJPBZ2EBvhr8M
+
+The address for the derivation path 44'/1815'/0'/0/2 is:<br/>
+Ae2tdPwUPEYxD9xNPBJTzYmtFVVWEPB6KW4TCDijQ4pDwU11wt5621PyCi4
 
 ## References
 


### PR DESCRIPTION
This specification describes a new method of deriving the master node of the key tree in Cardano hierarchical deterministic wallets which is primarily intended for use with SLIP-0039 Shamir's Secret-Sharing for Mnemonic Codes.