### PR TITLE
slip-0044: Add new coin KAL

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -409,9 +409,9 @@ index | hexa       | symbol | coin
 378   | 0x8000017a | XCX    | [XChain](https://github.com/xchainxchain)
 379   | 0x8000017b | SOX    | [SonicX](https://sonicx.org/)
 380   | 0x8000017c | NYZO   | [Nyzo](https://nyzo.co/)
-381   | 0x8000017d |        |
-382   | 0x8000017e | KAL    | [Kaleidochain](https://kaleidochain.io/)
-383   | 0x8000017f | KALTEST| [Kaleidochain](https://kaleidochain.io/)
+381   | 0x8000017d | KAL    | [Kaleidochain](https://kaleidochain.io/)
+382   | 0x8000017e |        | 
+383   | 0x8000017f |        | 
 384   | 0x80000180 | XSN    | [Stakenet](https://xsncoin.io/)
 385   | 0x80000181 |        |
 386   | 0x80000182 |        |

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -410,8 +410,8 @@ index | hexa       | symbol | coin
 379   | 0x8000017b | SOX    | [SonicX](https://sonicx.org/)
 380   | 0x8000017c | NYZO   | [Nyzo](https://nyzo.co/)
 381   | 0x8000017d |        |
-382   | 0x8000017e |        |
-383   | 0x8000017f |        |
+382   | 0x8000017e | KAL    | [Kaleidochain](https://kaleidochain.io/)
+383   | 0x8000017f | KALTEST| [Kaleidochain](https://kaleidochain.io/)
 384   | 0x80000180 | XSN    | [Stakenet](https://xsncoin.io/)
 385   | 0x80000181 |        |
 386   | 0x80000182 |        |


### PR DESCRIPTION
Add new coin for the Kaleidochain. KAL for mainnet.

Our codebase is [Kaleidochain](https://github.com/kaleidochain/kaleido) at GitHub. We implement a new standalone blockchain using newly algorand pure PoS consensus algorithom.

Thanks for your time.