### PR TITLE
Adding Mochimo BIP-0044 Code

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1032,6 +1032,7 @@ index | hexa       | symbol | coin
 1001  | 0x800003e9 | TT     | [ThunderCore](https://thundercore.com/)
 1002  | 0x800003ea | BKT    | [BanKitt](https://www.bankitt.network/)
 1024  | 0x80000400 | ONT    | [Ontology](https://ont.io)
+1027  | 0x80000403 | MCM    | [Mochimo](https://mochimo.org)
 1111  | 0x80000457 | BBC    | [Big Bitcoin](http://bigbitcoins.org/)
 1120  | 0x80000460 | RISE   | [RISE](https://rise.vision)
 1122  | 0x80000462 | CMT    | [CyberMiles Token](https://www.cybermiles.io)


### PR DESCRIPTION
On behalf of Mochimo, Stackoverflo (project creator), edit to add Mochimo to the hierarchy with identifier 0x80000403, as implemented in the Mojo Wallet.