### PR TITLE
Updated KUVA (#332) coin name and link to a web-site

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -360,7 +360,7 @@ index | hexa       | symbol | coin
 329   | 0x80000149 | AUDAX  | [AUDAX](https://www.audaxproject.io)
 330   | 0x8000014a | LUNA   | [Terra](https://terra.money)
 331   | 0x8000014b | ZPM    | [zPrime](https://github.com/zprimecoin/zprime)
-332   | 0x8000014c | KUVA   | [Kuva Utility Note](https://www.kuvacash.com)
+332   | 0x8000014c | KUVA   | [Kuva Util](https://www.kuva.com)
 333   | 0x8000014d | MEM    | [MemCoin](https://memcoin.org)
 334   | 0x8000014e | CS     | [Credits](https://credits.com)
 335   | 0x8000014f | SWIFT  | [SwiftCash](https://swiftcash.cc)


### PR DESCRIPTION
Updated name and site with the release of the [whitepaper](https://github.com/kuvabase/whitepaper)