### PR TITLE
Change to TON web address

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -424,7 +424,7 @@ index | hexa       | symbol | coin
 393   | 0x80000189 | HSN    | [Hyper Speed Network](https://www.hsn.link/)
 394   | 0x8000018a | CRO    | [Crypto.com Chain](https://github.com/crypto-com/chain)
 395   | 0x8000018b | UMBRU  | [Umbru](https://umbru.io)
-396   | 0x8000018c | TON    | [Telegram](https://https://test.ton.org/)
+396   | 0x8000018c | TON    | [Telegram Open Network](https://test.ton.org/)
 397   | 0x8000018d | NEAR   | [NEAR Protocol](https://nearprotocol.com/)
 398   | 0x8000018e | XPC    | [XPChain](https://www.xpchain.io/)
 399   | 0x8000018f | ZOC    | [01coin](https://01coin.io/)

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -424,7 +424,7 @@ index | hexa       | symbol | coin
 393   | 0x80000189 | HSN    | [Hyper Speed Network](https://www.hsn.link/)
 394   | 0x8000018a | CRO    | [Crypto.com Chain](https://github.com/crypto-com/chain)
 395   | 0x8000018b | UMBRU  | [Umbru](https://umbru.io)
-396   | 0x8000018c | TON    | [Telegram](https://ton-telegram.net)
+396   | 0x8000018c | TON    | [Telegram](https://https://test.ton.org/)
 397   | 0x8000018d | NEAR   | [NEAR Protocol](https://nearprotocol.com/)
 398   | 0x8000018e | XPC    | [XPChain](https://www.xpchain.io/)
 399   | 0x8000018f | ZOC    | [01coin](https://01coin.io/)


### PR DESCRIPTION
the official TON project address is https://test.ton.org
what is listed now is a scam website. Will report to github if not changed.