### PR TITLE
Assign number to Bitcoin Royale BTCR #440

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -468,7 +468,7 @@ index | hexa       | symbol | coin
 437   | 0x800001b5 |        |
 438   | 0x800001b6 |        |
 439   | 0x800001b7 |        |
-440   | 0x800001b8 |        |
+440   | 0x800001b8 | BTCR   | [Bitcoin Royale](https://bitcoinroyale.org)
 441   | 0x800001b9 |        |
 442   | 0x800001ba |        |
 443   | 0x800001bb |        |


### PR DESCRIPTION
I prefer a nice looking number to the next available number. I can see from how the list is populated that this is a common practice. Numbers are allocated in first come first serve and many coins have chosen "nice looking" numbers like "555 = Bitcoin Smart". I humbly request same treatment.