### PR TITLE
SLIP-0044: Added Ergo platform coin_type

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -457,7 +457,7 @@ index | hexa       | symbol | coin
 426   | 0x800001aa | BC     | [Bitcoin Confidential](https://www.bitcoinconfidential.cc/)
 427   | 0x800001ab | KTV    | [KmushiCoin](https://tierravivaplanet.com)
 428   | 0x800001ac | ZCR    | [ZCore](https://zcore.cash)
-429   | 0x800001ad |        |
+429   | 0x800001ad | ERG    | [Ergo](https://ergoplatform.org)
 430   | 0x800001ae | PESO   | [Criptopeso](https://criptopeso.io/)
 431   | 0x800001af |        |
 432   | 0x800001b0 |        |


### PR DESCRIPTION
Why 429 ?

"ergo" in ASCII is : 101 + 114 + 103 + 111 = 429

(EIP0003 - https://github.com/ergoplatform/eips/pull/1)