### PR TITLE
0173: Add IoTeX prefix ('io').

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -39,6 +39,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | [FujiCoin](http://www.fujicoin.org/)           | `fc`    | `tf`    | `fcrt`    |
 | [Groestlcoin](https://groestlcoin.org/)        | `grs`   | `tgrs`  | `grsrt`   |
 | [Handshake](https://handshake.org/)            | `hs`    | `ts`    | `rs`      |
+| [IoTeX](https://github.com/iotexproject/iotex-address) | `io` | `it` |         |
 | [IOV](https://www.iov.one/)                    | `iov`   | `tiov`  |           |
 | [Litecoin](https://litecoin.org/)              | `ltc`   | `tltc`  | `rltc`    |
 | [Monacoin](https://monacoin.org/)              | `mona`  | `tmona` | `rmona`   |

--- a/slip-0173.md
+++ b/slip-0173.md
@@ -39,7 +39,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | [FujiCoin](http://www.fujicoin.org/)           | `fc`    | `tf`    | `fcrt`    |
 | [Groestlcoin](https://groestlcoin.org/)        | `grs`   | `tgrs`  | `grsrt`   |
 | [Handshake](https://handshake.org/)            | `hs`    | `ts`    | `rs`      |
-| [IoTeX](https://github.com/iotexproject/iotex-address) | `io` | `it` |         |
+| [IoTeX](https://www.iotex.io/)                 | `io`    | `it`    |           |
 | [IOV](https://www.iov.one/)                    | `iov`   | `tiov`  |           |
 | [Litecoin](https://litecoin.org/)              | `ltc`   | `tltc`  | `rltc`    |
 | [Monacoin](https://monacoin.org/)              | `mona`  | `tmona` | `rmona`   |


### PR DESCRIPTION
Defined here:  https://github.com/iotexproject/iotex-address/blob/master/address/address.go
