### PR TITLE
Added coin type for Ethereum 2

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1092,6 +1092,7 @@ index | hexa       | symbol | coin
 2941  | 0x80000b7d | BND    | [Blocknode](https://blocknode.tech)
 3276  | 0x80000ccc | CCC    | [CodeChain](https://codechain.io/)
 3377  | 0x80000d31 | ROI    | [ROIcoin](https://roi-coin.com/)
+3600  | 0x80000e10 | ETH    | [Ether](https://ethereum.org/ether) (Ethereum 2)
 4040  | 0x80000fc8 | FC8    | [FCH Network](https://fch.network/)
 4096  | 0x80001000 | YEE    | [YeeCo](https://www.yeeco.io/)
 4218  | 0x8000107a | IOTA   | [IOTA](https://www.iota.org/)


### PR DESCRIPTION
Ethereum 2 continues to use Ether as its network currency, however it is stored and addressed in a different fashion.  Most notably, the curve used is BLS12-381.  As such, although they are technically the same coin they are different coin types and a new ID is required to avoid potential issues.

This allocates a new coin type for Ethereum 2: 3600.  This value has been listed in ERC-2334 and will become the standard for all HD key derivation systems for this chain.