### PR TITLE
slip-0044: Added Bithereum [BTH]

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -497,7 +497,7 @@ index | hexa       | symbol | coin
 466   | 0x800001d2 | ERE    | [EtherCore](https://ethercore.org)
 467   | 0x800001d3 |        |
 468   | 0x800001d4 | CPS    | [Capricoin+](https://capricoin.org)
-469   | 0x800001d5 |        |
+469   | 0x800001d5 | BTH    | [Bithereum](https://bithereum.network)
 470   | 0x800001d6 |        |
 471   | 0x800001d7 |        |
 472   | 0x800001d8 |        |


### PR DESCRIPTION
Used the next available spot to add Bithereum at 0x800001d5 (469). Would greatly appreciate if this could be merged. Thanks.