### PR TITLE
Update slip-0044.md: add MESG token

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -498,7 +498,7 @@ index | hexa       | symbol | coin
 467   | 0x800001d3 |        |
 468   | 0x800001d4 | CPS    | [Capricoin+](https://capricoin.org)
 469   | 0x800001d5 | BTH    | [Bithereum](https://bithereum.network)
-470   | 0x800001d6 |        |
+470   | 0x800001d6 | MESG   | [MESG](https://mesg.com)
 471   | 0x800001d7 |        |
 472   | 0x800001d8 |        |
 473   | 0x800001d9 |        |


### PR DESCRIPTION
Added MESG token to slip-0044.md at number 470.
I didn't use number 467 (first available number) because PR https://github.com/satoshilabs/slips/pull/853 will use it.