### PR TITLE
RNG added to slip-0044

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -506,7 +506,7 @@ index | hexa       | symbol | coin
 475   | 0x800001db | BARE   | [BARE Network](https://bare.network)
 476   | 0x800001dc | GLEEC  | [GleecBTC](https://gleecbtc.com)
 477   | 0x800001dd | CLR    | [Color Coin](https://color-platform.org)
-478   | 0x800001de |        |
+478   | 0x800001de | RNG    | [Ring](https://ringcoin.tech)
 479   | 0x800001df |        |
 480   | 0x800001e0 |        |
 481   | 0x800001e1 |        |


### PR DESCRIPTION
Ring is a new chain from the Litecoin Cash developers, offering symbiotic mining between three different blocktypes and the widest ever initial distribution.