### PR TITLE
Add BCTR (Decentralized Identifier) as 1032

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1035,6 +1035,7 @@ index | hexa       | symbol | coin
 1024  | 0x80000400 | ONT    | [Ontology](https://ont.io)
 1026  | 0x80000402 | KEX    | [Kira Exchange Token](https://kiraex.com)
 1027  | 0x80000403 | MCM    | [Mochimo](https://mochimo.org)
+1032  | 0x80000408 | BTCR   | [BTCR](https://github.com/did-btcr)
 1111  | 0x80000457 | BBC    | [Big Bitcoin](http://bigbitcoins.org/)
 1120  | 0x80000460 | RISE   | [RISE](https://rise.vision)
 1122  | 0x80000462 | CMT    | [CyberMiles Token](https://www.cybermiles.io)


### PR DESCRIPTION
Not technically a new coin, but the W3C BTCR DID method leverages bitcoin transactions for keys to use in decentralized identifiers, and we want to be sure that wallets don't accidentally spend an identity transaction, so we need use different part of the HD tree.

-- Christopher Allen (co-chair W3C Credentials CG, co-lead BTCR DID Method)