### PR TITLE
SLIP-0044: Add entry for Elrond

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1066,6 +1066,7 @@ index | hexa       | symbol | coin
 1999  | 0x800007cf | COLX   | [ColossusXT](https://colossusxt.io/)
 2000  | 0x800007d0 | GIN    | [GinCoin](https://gincoin.io/)
 2001  | 0x800007d1 | MNP    | [MNPCoin](https://mnpcoin.pro/)
+2003  | 0x800007d3 | ERD    | [Elrond](https://elrond.com/)
 2017  | 0x800007e1 | KIN    | [Kin](https://www.kinecosystem.org/)
 2018  | 0x800007e2 | EOSC   | [EOSClassic](https://eos-classic.io/)
 2019  | 0x800007e3 | GBT    | [GoldBean Token](http://www.adfunds.org/)

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -536,7 +536,7 @@ index | hexa       | symbol | coin
 505   | 0x800001f9 | HASH   | [Provenance](https://provenance.io)
 506   | 0x800001fa | CLX    | [CasperLabs](https://casperlabs.io)
 507   | 0x800001fb | EARTH  | [EARTH](https://www.earth.engineering)
-508   | 0x800001fc |        |
+508   | 0x800001fc | ERD    | [Elrond](https://elrond.com/)
 509   | 0x800001fd |        |
 510   | 0x800001fe | KOTO   | [Koto](https://ko-to.org/)
 511   | 0x800001ff |        |
@@ -1066,7 +1066,6 @@ index | hexa       | symbol | coin
 1999  | 0x800007cf | COLX   | [ColossusXT](https://colossusxt.io/)
 2000  | 0x800007d0 | GIN    | [GinCoin](https://gincoin.io/)
 2001  | 0x800007d1 | MNP    | [MNPCoin](https://mnpcoin.pro/)
-2003  | 0x800007d3 | ERD    | [Elrond](https://elrond.com/)
 2017  | 0x800007e1 | KIN    | [Kin](https://www.kinecosystem.org/)
 2018  | 0x800007e2 | EOSC   | [EOSClassic](https://eos-classic.io/)
 2019  | 0x800007e3 | GBT    | [GoldBean Token](http://www.adfunds.org/)


### PR DESCRIPTION
We are currently configuring key derivation for our wallet & wallet-like applications and for our extension to TrustWallet Core library - as seen below:

https://github.com/ElrondNetwork/wallet-core/blob/new-coin-elrond/coins.json#L1340

Therefore, we would like to add an entry for ERD in the SLIP-0044 registry.

