### PR TITLE
Register SLIP-44 coin type for CHI.

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -537,7 +537,7 @@ index | hexa       | symbol | coin
 506   | 0x800001fa | CLX    | [CasperLabs](https://casperlabs.io)
 507   | 0x800001fb | EARTH  | [EARTH](https://www.earth.engineering)
 508   | 0x800001fc | ERD    | [Elrond](https://elrond.com/)
-509   | 0x800001fd |        |
+509   | 0x800001fd | CHI    | [Xaya](https://xaya.io/)
 510   | 0x800001fe | KOTO   | [Koto](https://ko-to.org/)
 511   | 0x800001ff |        |
 512   | 0x80000200 | XRD    | [Radiant](https://radiant.cash/)


### PR DESCRIPTION
CHI is the native coin of the [Xaya network](https://xaya.io/).  We have an [Electrum-based wallet](https://github.com/xaya/electrum-chi) based on BIP-44, as well as a [Bitcoin-Core-based wallet](https://github.com/xaya/xaya) which uses BIP-44/49/84 as well since the introduction of [descriptor wallets](https://github.com/bitcoin/bitcoin/pull/16528).  Thus we need a coin type.