### PR TITLE
slip-0044: add SierraCoin

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -545,7 +545,7 @@ index | hexa       | symbol | coin
 514   | 0x80000202 | AETH   | [AETH](https://aeth.io)
 515   | 0x80000203 | DNA    | [Idena](https://idena.io)
 516   | 0x80000204 | VEE    | [Virtual Economy Era](https://www.vee.tech/)
-517   | 0x80000205 |        |
+517   | 0x80000205 | SIERRA | [SierraCoin](https://sierracoin.org/)
 518   | 0x80000206 | LET    | [Linkeye](https://www.linkeye.com/)
 519   | 0x80000207 |        |
 520   | 0x80000208 | BTCV   | [BitcoinVIP](https://www.bitvip.org/)


### PR DESCRIPTION
New major version 3.0 of SierraCoin is planned for release in June.
It supports HD wallets, so the coin type has to be properly registered.