### PR TITLE
slip-0044: specify hardened path for hns.

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1100,7 +1100,7 @@ index | hexa       | symbol | coin
 4242  | 0x80001092 | AXE    | [Axe](https://github.com/AXErunners/axe)
 4343  | 0x000010f7 | XYM    | [Symbol](https://github.com/nemtech/catapult-server)
 5248  | 0x00001480 | FIC    | [FIC](https://ficnetwork.com)
-5353  | 0x000014e9 | HNS    | [Handshake](https://handshake.org)
+5353  | 0x800014e9 | HNS    | [Handshake](https://handshake.org)
 5555  | 0x800015b3 | FUND   | [Unification](https://unification.com)
 5757  | 0x8000167d | STX    | [Blockstack](https://github.com/blockstack/blockstack-core)
 5920  | 0x80001720 | SLU    | [SILUBIUM](https://github.com/SilubiumProject/slucore)


### PR DESCRIPTION
The cointype uses hardened derivation. This was an oversight in the initial pull request to this repo.

https://github.com/handshake-org/ledger-app-hns/blob/master/src/utils.h#L27