### PR TITLE
TON Updates

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -424,7 +424,7 @@ index | hexa       | symbol | coin
 393   | 0x80000189 | HSN    | [Hyper Speed Network](https://www.hsn.link/)
 394   | 0x8000018a | CRO    | [Crypto.com Chain](https://github.com/crypto-com/chain)
 395   | 0x8000018b | UMBRU  | [Umbru](https://umbru.io)
-396   | 0x8000018c | TON    | [Telegram Open Network](https://test.ton.org/)
+396   | 0x8000018c | TON    | [The Open Network](https://freeton.org/)
 397   | 0x8000018d | NEAR   | [NEAR Protocol](https://nearprotocol.com/)
 398   | 0x8000018e | XPC    | [XPChain](https://www.xpchain.io/)
 399   | 0x8000018f | ZOC    | [01coin](https://01coin.io/)


### PR DESCRIPTION
Reflecting change in TON launch (https://decrypt.co/28101/free-ton-blockchain-network-launch). Telegram has withdraw from TON. Community has launched the network as Free TON with the same open source technology. Domain changed.