### PR TITLE
SLIP-0173: Add Omni Human Readable Parts

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -48,6 +48,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | [Monacoin](https://monacoin.org/)              | `mona`     | `tmona` | `rmona`     |
 | [Myriad](https://myriadcoin.org/)              | `my`       | `tm`    |             |
 | [Namecoin](https://www.namecoin.org/)          | `nc`       | `tn`    | `ncrt`      |
+| [Omni](https://www.omnilayer.org)              | `o`        | `to`    | `ocrt`      |
 | [Peercoin](https://www.peercoin.net)           | `xpc`      | `tpc`   |             |
 | [PKT](https://github.com/pkt-cash/pktd)        | `pkt`      | `tpk`   |             |
 | [PlatON](https://platon.network/)              | `lat`      | `lax`   |             |


### PR DESCRIPTION
Omni is working on Segwit support and intends to require unique Bech32 addresses when sending  Omni Layer tokens on the Bitcoin chain. We would like to reserve the `o`, `to`, and `ort` Human Readable Parts.

The Human-readable parts are specified in OLE-300: https://github.com/OmniLayer/Documentation/blob/master/OLEs/ole-300.adoc#human-readable-part