### PR TITLE
Added Edgeware to the first empty slot in the list

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -551,7 +551,7 @@ index | hexa       | symbol | coin
 520   | 0x80000208 | BTCV   | [BitcoinVIP](https://www.bitvip.org/)
 521   | 0x80000209 | ABA    | [Dabacus](https://www.dabacus.org)
 522   | 0x8000020a | SCC    | [StakeCubeCoin](https://stakecube.net)
-523   | 0x8000020b |        |
+523   | 0x8000020b | EDG    | [Edgeware](https://edgewa.re/)
 524   | 0x8000020c | AMS    | [AmsterdamCoin](https://www.amsterdamcoin.com/)
 525   | 0x8000020d |        |
 526   | 0x8000020e | BU     | [BUMO](https://www.bumo.io/)


### PR DESCRIPTION
Hi, I wanted to add Edgeware so that it can be used in the implementation of BIP44 by hardware wallets vendors. I am familiar with how the protocol works, but not with the steps that are to be made to obtain an "official" slot.
Is it just sufficient to modify the list in a first-come-first served basis, or are the slots listed here coming from another reviewed process that I should have completed first?
Does this list hold some kind of official status too? It seems many hardware wallet vendors other than Satoshilabs use similar information as the one contained here into their products, but I am not sure whether this list is the original source or not. If it isn't could you link me?
Thanks a lot.