### PR TITLE
ADD THORChain (RUNE) Coin Number

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -959,7 +959,7 @@ index | hexa       | symbol | coin
 928   | 0x800003a0 |        |
 929   | 0x800003a1 |        |
 930   | 0x800003a2 |        |
-931   | 0x800003a3 |        |
+931   | 0x800003a3 |  RUNE  | [THORChain (RUNE)](https://thorchain.org)
 932   | 0x800003a4 |        |
 933   | 0x800003a5 |        |
 934   | 0x800003a6 |        |


### PR DESCRIPTION
This adds THORChain (RUNE) as a coin type, 931.

Implemented in Wallet code: https://gitlab.com/thorchain/asgardex-common/asgardex-crypto/-/blob/master/src/crypto.ts#L12