### PR TITLE
Add Secret Network to slip-044

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -557,7 +557,7 @@ index | hexa       | symbol | coin
 526   | 0x8000020e | BU     | [BUMO](https://www.bumo.io/)
 527   | 0x8000020f | GRAM   | [GRAM](https://github.com/tongram)
 528   | 0x80000210 | YAP    | [Yapstone](https://yapstone.pro/)
-529   | 0x80000211 |        |
+529   | 0x80000211 | SCRT   | [Secret Network](https://scrt.network/)
 530   | 0x80000212 |        |
 531   | 0x80000213 |        |
 532   | 0x80000214 |        |


### PR DESCRIPTION
Adds Secret Network coin SCRT as a coin type 529 (first available) to slip-0044.

Implemented at: https://github.com/enigmampc/wallet-core/blob/f77d966c5fa8fd76864cf3a6265c998811663c2e/coins.json#L1274