### PR TITLE
Add Novo as coin type 530 (first available) to slip-0044

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -558,7 +558,7 @@ index | hexa       | symbol | coin
 527   | 0x8000020f | GRAM   | [GRAM](https://github.com/tongram)
 528   | 0x80000210 | YAP    | [Yapstone](https://yapstone.pro/)
 529   | 0x80000211 | SCRT   | [Secret Network](https://scrt.network/)
-530   | 0x80000212 |        |
+530   | 0x80000212 | NOVO   | [Novo](https://novocurrency.com/)
 531   | 0x80000213 |        |
 532   | 0x80000214 |        |
 533   | 0x80000215 | PRJ    | [ProjectCoin](https://projectcoin.net/)


### PR DESCRIPTION
Implemented at: https://github.com/novocurrency/novocurrency-core/blob/master/src/wallet/account.cpp#L131