### PR TITLE
add JPYS

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1052,6 +1052,7 @@ index | hexa       | symbol | coin
 1688  | 0x80000698 | BCX    | [BitcoinX](https://bcx.org)
 1729  | 0x800006c1 | XTZ    | [Tezos](https://tezos.com)
 1776  | 0x800006f0 | LBTC   | [Liquid BTC](https://blockstream.com/liquid/)
+1784  | 0x800006F8 | JPYS   | [JPY Stablecoin](https://settlenet.io/)
 1815  | 0x80000717 | ADA    | [Cardano](https://www.cardanohub.org/en/home/)
 1856  | 0x80000743 | TES    | [Teslacoin](https://www.tesla-coin.com/)
 1901  | 0x8000076d | CLC    | [Classica](https://github.com/classica/)


### PR DESCRIPTION
Adds JPYS to slip-0044

SETTLENET JPY is a Japanese yen-denominated token that is used solely as method of payment for trading between the domestic and foreign entities that have underwent KYC/AML checks by Crypto Garage. SETTLENET JPY is issued as an Issued Asset on the Liquid Network, and is issued directly to the user’s Liquid Wallet. The underlying yen assets are fully segregated to a trust bank.

https://settlenet.io/
https://blockstream.info/liquid/asset/3438ecb49fc45c08e687de4749ed628c511e326460ea4336794e1cf02741329e
