### PR TITLE
Slip-0044 add AUDL(#1618)

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1047,6 +1047,7 @@ index | hexa       | symbol | coin
 1524  | 0x800005f4 |        | [Taler](http://taler.site)
 1533  | 0x800005fd | BEAM   | [Beam](https://www.beam.mw/)
 1616  | 0x80000650 | ELF    | [AELF](https://aelf.io)
+1618  | 0x80000652 | AUDL   | [AUDL](https://aud.one)
 1620  | 0x80000654 | ATH    | [Atheios](https://atheios.com)
 1642  | 0x8000066a | NEW    | [Newton](https://www.newtonproject.org)
 1688  | 0x80000698 | BCX    | [BitcoinX](https://bcx.org)


### PR DESCRIPTION
Adds AUDL to slip-0044

AUDL is an Australian Dollar token issued on the Liquid network. It is used as an interexchange/OTC desk transport mechanism.

The underlying Australian Dollars are held in a local AUD bank account. 

Issuance and Redemption will occur at https://aud.one

The Liquid Asset ID is 

https://blockstream.info/liquid/asset/f59c5f3e8141f322276daa63ed5f307085808aea6d4ef9ba61e28154533fdec7 
