### PR TITLE
slip-0044: add Valorbit (VAL) coin (#538)

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -566,7 +566,7 @@ index | hexa       | symbol | coin
 535   | 0x80000217 |        |
 536   | 0x80000218 |        |
 537   | 0x80000219 |        |
-538   | 0x8000021a |        |
+538   | 0x8000021a | VAL    | [Valorbit](https://valorbit.com/)
 539   | 0x8000021b |        |
 540   | 0x8000021c | SMESH  | [Spacemesh Coin](https://spacemesh.io)
 541   | 0x8000021d |        |


### PR DESCRIPTION
This is a request to include Valorbit (VAL) as coin type #538 .

The SLIP-0044 type is defined in code over here:

https://github.com/valorbit/go-ethereum/blob/release/1.9-val/accounts/hd.go#L29

Thank you.