### PR TITLE
Typo in Slip77

### DIFF
--- a/slip-0077.md
+++ b/slip-0077.md
@@ -12,7 +12,7 @@ Created: 2019-06-15
 ## Abstract
 
 This document describes a method for blinding key derivation
-for Confidential Transactions, using a determinstic hierarchy.
+for Confidential Transactions, using a deterministic hierarchy.
 
 ## General design
 


### PR DESCRIPTION
This commit fixes a typo in the document, from "determinstic" to `deterministic`