### PR TITLE
Slip-0044 add AVAX(#9000)

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1114,6 +1114,7 @@ index | hexa       | symbol | coin
 8888  | 0x800022b8 | SBTC   | [Super Bitcoin](https://www.superbtc.org)
 8964  | 0x80002304 | NULS   | [NULS](https://nuls.io)
 8999  | 0x80002327 | BTP    | [Bitcoin Pay](http://www.btceasypay.com)
+9000  | 0x80002328 | AVAX   | [Avalanche](https://www.avalabs.org)
 9797  | 0x80002645 | NRG    | [Energi](https://www.energi.world/)
 9888  | 0x800026a0 | BTF    | [Bitcoin Faith](http://bitcoinfaith.org)
 9999  | 0x8000270f | GOD    | [Bitcoin God](https://www.bitcoingod.org)


### PR DESCRIPTION
Add AVAX to SLIP-0044(#9000)

The SLIP-0044 type is defined in [our wallet](https://github.com/ava-labs/ava-wallet/blob/13be5ca736b7714cf14c6c9ac1116408babf60c6/src/js/AvaHdWallet.ts#L24)

[More info on AVA Labs and Avalanche](https://www.avalabs.org)

Thank you.