### PR TITLE
Add huobichain

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -947,7 +947,7 @@ index | hexa       | symbol | coin
 916   | 0x80000394 | META   | [Metadium](https://www.metadium.com/)
 917   | 0x80000395 |        |
 918   | 0x80000396 |        |
-919   | 0x80000397 |        |
+919   | 0x80000397 | HUOBICHAIN | [HuobiChain](https://www.huobichain.com/)
 920   | 0x80000398 |        |
 921   | 0x80000399 |        |
 922   | 0x8000039a |        |


### PR DESCRIPTION
Hey, we want to apply a new coin type code for huobichain
As huobichain is based on muta, and it's coin type is 918, we prefer to apply 919 as our coin type code. 
Please approve, thanks