### PR TITLE
Slip-0044 add KTS

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -584,7 +584,7 @@ index | hexa       | symbol | coin
 553   | 0x80000229 | HBC    | [HuobiChain](https://www.huobichain.com/)
 554   | 0x8000022a | SPARK  | [Flare Spark](https://flare.xyz/)
 555   | 0x8000022b | BCS    | [Bitcoin Smart](http://bcs.info)
-556   | 0x8000022c |        |
+556   | 0x8000022c | KTS    | [Kratos](https://github.com/KuChainNetwork/kratos)
 557   | 0x8000022d | LKR    | [Lkrcoin](https://lkrcoin.io/)
 558   | 0x8000022e | TAO    | [Tao](https://tao.network)
 559   | 0x8000022f |        |


### PR DESCRIPTION
`KTS` is the core token in [kratos network](https://github.com/KuChainNetwork/kratos).

Add KTS in 556.

Thank you.