### PR TITLE
SLIP-0044: Add TOP

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -590,7 +590,7 @@ index | hexa       | symbol | coin
 559   | 0x8000022f | XWC    | [Whitecoin](https://www.whitecoin.info/)
 560   | 0x80000230 | DEAL   | [DEAL](https://idealcash.io/)
 561   | 0x80000231 | NTY    | [Nexty](https://nexty.io/)
-562   | 0x80000232 |        |
+562   | 0x80000232 | TOP    | [TOP NetWork](https://www.topnetwork.org)
 563   | 0x80000233 |        |
 564   | 0x80000234 |        |
 565   | 0x80000235 |        |


### PR DESCRIPTION
Adds TOP to slip-0044.

TOP is the token of TOP Network blockchain ecosystem, which is used to pay nodes that provide resource and serve as the carrier of value exchange.