### PR TITLE
SLIP-0044: Update character casing of coin name for BTCD

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -80,7 +80,7 @@ index | hexa       | symbol | coin
 49    | 0x80000031 | GCR    | Global Currency Reserve (GCRcoin)
 50    | 0x80000032 | NVC    | [Novacoin](https://github.com/novacoin-project/novacoin)
 51    | 0x80000033 | AC     | [Asiacoin](https://github.com/AsiaCoin/AsiaCoinFix)
-52    | 0x80000034 | BTCD   | [Bitcoindark](https://github.com/jl777/btcd)
+52    | 0x80000034 | BTCD   | [BitcoinDark](https://github.com/jl777/btcd)
 53    | 0x80000035 | DOPE   | [Dopecoin](https://github.com/dopecoin-dev/DopeCoinV3)
 54    | 0x80000036 | TPC    | [Templecoin](https://github.com/9cat/templecoin)
 55    | 0x80000037 | AIB    | [AIB](https://github.com/iobond/aib)


### PR DESCRIPTION
This commit simply corrects the character casing of the BTCD coin name from "Bitcoindark" to "BitcoinDark" per [the official GitHub repository](https://github.com/jl777/btcd).