### PR TITLE
SLIP-0044: Change Flare Spark symbol to FLR

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -582,7 +582,7 @@ index | hexa       | symbol | coin
 551   | 0x80000227 | STR    | [Straightedge](https://straighted.ge/)
 552   | 0x80000228 | SUM    | [Sumcoin](https://sumcoin.org)
 553   | 0x80000229 | HBC    | [HuobiChain](https://www.huobichain.com/)
-554   | 0x8000022a | SPARK  | [Flare Spark](https://flare.xyz/)
+554   | 0x8000022a | FLR    | [Flare Spark](https://flare.xyz/)
 555   | 0x8000022b | BCS    | [Bitcoin Smart](http://bcs.info)
 556   | 0x8000022c | KTS    | [Kratos](https://github.com/KuChainNetwork/kratos)
 557   | 0x8000022d | LKR    | [Lkrcoin](https://lkrcoin.io/)


### PR DESCRIPTION
Discussed with the Flare team, they decided to use `FLR` as ticker.