### PR TITLE
SLIP-0044: Add Chia/XCH at 8444

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1111,6 +1111,7 @@ index | hexa       | symbol | coin
 7777  | 0x80001e61 | BTV    | [Bitvote](https://www.bitvote.one)
 8000  | 0x80001f40 | SKY    | [Skycoin](https://www.skycoin.net)
 8339  | 0x80002093 | BTQ    | [BitcoinQuark](https://www.bitcoinquark.org)
+8444  | 0x800020FC | XCH    | [Chia](https://github.com/Chia-Network/chia-blockchain)
 8888  | 0x800022b8 | SBTC   | [Super Bitcoin](https://www.superbtc.org)
 8964  | 0x80002304 | NULS   | [NULS](https://nuls.io)
 8999  | 0x80002327 | BTP    | [Bitcoin Pay](http://www.btceasypay.com)

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1111,7 +1111,7 @@ index | hexa       | symbol | coin
 7777  | 0x80001e61 | BTV    | [Bitvote](https://www.bitvote.one)
 8000  | 0x80001f40 | SKY    | [Skycoin](https://www.skycoin.net)
 8339  | 0x80002093 | BTQ    | [BitcoinQuark](https://www.bitcoinquark.org)
-8444  | 0x800020FC | XCH    | [Chia](https://github.com/Chia-Network/chia-blockchain)
+8444  | 0x800020fc | XCH    | [Chia](https://www.chia.net)
 8888  | 0x800022b8 | SBTC   | [Super Bitcoin](https://www.superbtc.org)
 8964  | 0x80002304 | NULS   | [NULS](https://nuls.io)
 8999  | 0x80002327 | BTP    | [Bitcoin Pay](http://www.btceasypay.com)


### PR DESCRIPTION
We would like to add Chia's Bip44 HD scheme to the list.

Note that this is a duplicate ticker symbol to 15/XCH/Clearinghouse coin.

It looks like Clearinghouse died in mid 2016. 
Coinmarketcap - https://coinmarketcap.com/currencies/clearinghouse/
All their relevant links 404 or equivalently fail.

![image](https://user-images.githubusercontent.com/30377676/97060759-3de2c600-1549-11eb-981d-717d44e71045.png)

Do we need to do anything additional to address the XCH point?

Wallet Derive Keys: https://github.com/Chia-Network/chia-blockchain/blob/main/src/wallet/derive_keys.py

I saw in a previous PR that there is a preference to take the next available but that's too late for us. Our farmers have already built about 12PiB of plots that rely on this derivation. Note that 8444 is our IANA applied for port.

Happy to address anything else I can.
