### PR TITLE
slip-0044: Fix typo.

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -606,7 +606,7 @@ index | hexa       | symbol | coin
 575   | 0x8000023f | VIVT   | [VIDT Datalink](https://about.v-id.org/)
 576   | 0x80000240 | BPS    | [BitcoinPoS](https://bitcoinpos.net/)
 577   | 0x80000241 | NKN    | [NKN](https://www.nkn.org/)
-578   | 0x80000242 | ICL    | [ILCOIN}(https://ilcoincrypto.com/)
+578   | 0x80000242 | ICL    | [ILCOIN](https://ilcoincrypto.com/)
 579   | 0x80000243 | BONO   | [Bonorum](https://www.bonorum.io/)
 580   | 0x80000244 | PLC    | [PLATINCOIN](https://platincoin.com/en)
 581   | 0x80000245 | DUN    | [Dune](https://dune.network)


### PR DESCRIPTION
Just fix `}` to `]`.