### PR TITLE
Add BCHA to slip-0044

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1056,6 +1056,7 @@ index | hexa       | symbol | coin
 1784  | 0x800006F8 | JPYS   | [JPY Stablecoin](https://settlenet.io/)
 1815  | 0x80000717 | ADA    | [Cardano](https://www.cardanohub.org/en/home/)
 1856  | 0x80000743 | TES    | [Teslacoin](https://www.tesla-coin.com/)
+1899  | 0x8000076b | SLPA   | [BCHA token](https://www.bitcoinabc.org)
 1901  | 0x8000076d | CLC    | [Classica](https://github.com/classica/)
 1919  | 0x8000077f | VIPS   | [VIPSTARCOIN](https://www.vipstarcoin.jp/)
 1926  | 0x80000786 | CITY   | [City Coin](https://city-chain.org/)

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -927,7 +927,7 @@ index | hexa       | symbol | coin
 896   | 0x80000380 |        |
 897   | 0x80000381 |        |
 898   | 0x80000382 |        |
-899   | 0x80000383 |        |
+899   | 0x80000383 | BCHA   | [BCHA](https://www.bitcoinabc.org/)
 900   | 0x80000384 | LMO    | [Lumeneo](https://lumeneo.network/)
 901   | 0x80000385 |        |
 902   | 0x80000386 |        |


### PR DESCRIPTION
Bitcoin ABC will start using 899 for derivation paths in regular wallets, and 1899 for SLP aware wallets.

See https://github.com/Bitcoin-ABC/ElectrumABC/pull/62 for adoption of the new derivation path in Electrum ABC.
[CashTab](https://cashtabapp.com/#/) will implement these new derivation paths within a week or two.