### PR TITLE
slip-0044: Update after project rebranding

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -241,7 +241,7 @@ index | hexa       | symbol | coin
 210   | 0x800000d2 | NEET   | [NEETCOIN](https://neetcoin.jp/)
 211   | 0x800000d3 | BOPO   | [BopoChain](http://www.bopochain.org/)
 212   | 0x800000d4 | OOT    | [Utrum](https://utrum.io/ootcoin/)
-213   | 0x800000d5 | XSPEC  | [Spectrecoin](https://spectreproject.io/)
+213   | 0x800000d5 | ALIAS  | [Alias](https://alias.cash/)
 214   | 0x800000d6 | MONK   | [Monkey Project](https://www.monkey.vision)
 215   | 0x800000d7 | BOXY   | [BoxyCoin](http://www.boxycoin.org/)
 216   | 0x800000d8 | FLO    | [Flo](https://www.flo.cash/)


### PR DESCRIPTION
The _Spectrecoin_ project has rebranded to _Alias_ on October 1st, 2020. There are no blockchain related changes, just the new name.