### PR TITLE
slip-0044: rebrand STB

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -591,7 +591,7 @@ index | hexa       | symbol | coin
 560   | 0x80000230 | DEAL   | [DEAL](https://idealcash.io/)
 561   | 0x80000231 | NTY    | [Nexty](https://nexty.io/)
 562   | 0x80000232 | TOP    | [TOP NetWork](https://www.topnetwork.org)
-563   | 0x80000233 | STB    | [Stakebird](https://www.stakebird.com/)
+563   | 0x80000233 | STARS  | [Stargaze](https://www.stargaze.fi/)
 564   | 0x80000234 | AG     | [Agoric](https://agoric.com/)
 565   | 0x80000235 | CICO   | [Coinicles](https://github.com/coinicles/cico)
 566   | 0x80000236 | IRIS   | [Irisnet](https://www.irisnet.org/)


### PR DESCRIPTION
STB rebranded as STARS. STB was never deployed to mainnet.