### PR TITLE
Rebranding of SnowGem to TENT

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -438,7 +438,7 @@ index | hexa       | symbol | coin
 407   | 0x80000197 | HDD    | [HDDCash](https://hdd.cash)
 408   | 0x80000198 | SUGAR  | [Sugarchain](https://sugarchain.org/)
 409   | 0x80000199 | AILE   | [AileCoin](https://ailecoin.com/)
-410   | 0x8000019a | XSG    | [SnowGem](https://snowgem.org/)
+410   | 0x8000019a | TENT    | [TENT](https://tent.app/)
 411   | 0x8000019b | TAN    | [Tangerine Network](https://tangerine-network.io)
 412   | 0x8000019c | AIN    | [AIN](https://www.ainetwork.ai)
 413   | 0x8000019d | MSR    | [Masari](https://getmasari.org)


### PR DESCRIPTION
Lately SnowGem rebranded to TENT so this is just an actualization of the coin name.