### PR TITLE
slip-0044: add BDB

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -850,7 +850,7 @@ index | hexa       | symbol | coin
 819   | 0x80000333 |        |
 820   | 0x80000334 | CLO    | [Callisto](http://callisto.network/)
 821   | 0x80000335 |        |
-822   | 0x80000336 |        |
+822   | 0x80000336 | BDB    | [BigchainDB](https://github.com/bigchaindb/)
 823   | 0x80000337 |        |
 824   | 0x80000338 |        |
 825   | 0x80000339 |        |


### PR DESCRIPTION
Hello Satoshilabs!

This is a request to add BigchainDB cointype under the index 822.
Here are the wallet implemetations:
https://github.com/bigchaindb/bigchaindb-wallet
https://github.com/s1seven/js-bigchaindb-wallet
