### PR TITLE
Update the status of all SLIPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,27 +14,27 @@ Each SLIP should provide a concise technical specification of the feature and a 
 | Number                    | Title                                                                 | Type          | Status   |
 |---------------------------|-----------------------------------------------------------------------|---------------|----------|
 | [SLIP-0000](slip-0000.md) | SLIP Template                                                         | Informational | Accepted |
-| [SLIP-0010](slip-0010.md) | Universal private key derivation from master private key              | Standard      | Draft    |
-| [SLIP-0011](slip-0011.md) | Symmetric encryption of key-value pairs using deterministic hierarchy | Standard      | Draft    |
+| [SLIP-0010](slip-0010.md) | Universal private key derivation from master private key              | Standard      | Final    |
+| [SLIP-0011](slip-0011.md) | Symmetric encryption of key-value pairs using deterministic hierarchy | Standard      | Final    |
 | [SLIP-0012](slip-0012.md) | Public key encryption using deterministic hierarchy                   | Standard      | Draft    |
-| [SLIP-0013](slip-0013.md) | Authentication using deterministic hierarchy                          | Standard      | Draft    |
-| [SLIP-0014](slip-0014.md) | Stress Test Deterministic Wallet                                      | Informational | Draft    |
-| [SLIP-0015](slip-0015.md) | Format for Bitcoin metadata and its encryption in HD wallets          | Standard      | Draft    |
-| [SLIP-0016](slip-0016.md) | Format for password storage and its encryption                        | Standard      | Draft    |
-| [SLIP-0017](slip-0017.md) | Elliptic Curve Diffie-Hellman using deterministic hierarchy           | Standard      | Draft    |
+| [SLIP-0013](slip-0013.md) | Authentication using deterministic hierarchy                          | Standard      | Final    |
+| [SLIP-0014](slip-0014.md) | Stress Test Deterministic Wallet                                      | Informational | Active   |
+| [SLIP-0015](slip-0015.md) | Format for Bitcoin metadata and its encryption in HD wallets          | Standard      | Final    |
+| [SLIP-0016](slip-0016.md) | Format for password storage and its encryption                        | Standard      | Final    |
+| [SLIP-0017](slip-0017.md) | Elliptic Curve Diffie-Hellman using deterministic hierarchy           | Standard      | Final    |
 | [SLIP-0018](slip-0018.md) | reserved (CoSi)                                                       | Standard      | Draft    |
-| [SLIP-0019](slip-0019.md) | Proof of Ownership                                                    | Standard      | Draft    |
+| [SLIP-0019](slip-0019.md) | Proof of Ownership                                                    | Standard      | Accepted |
 | [SLIP-0020](slip-0020.md) | Proof of User Confirmation                                            | Standard      | Draft    |
-| [SLIP-0021](slip-0021.md) | Hierarchical derivation of symmetric keys                             | Standard      | Draft    |
-| [SLIP-0022](slip-0022.md) | FIDO2 Credential ID format for HD wallets                             | Standard      | Draft    |
-| [SLIP-0023](slip-0023.md) | Cardano HD master node derivation from a master seed                  | Standard      | Draft    |
+| [SLIP-0021](slip-0021.md) | Hierarchical derivation of symmetric keys                             | Standard      | Final    |
+| [SLIP-0022](slip-0022.md) | FIDO2 Credential ID format for HD wallets                             | Standard      | Final    |
+| [SLIP-0023](slip-0023.md) | Cardano HD master node derivation from a master seed                  | Standard      | Final    |
 | [SLIP-0032](slip-0032.md) | Extended serialization format for BIP-32 wallets                      | Standard      | Draft    |
-| [SLIP-0039](slip-0039.md) | Shamir's Secret-Sharing for Mnemonic Codes                            | Standard      | Draft    |
-| [SLIP-0044](slip-0044.md) | Registered coin types for BIP-0044                                    | Standard      | Draft    |
-| [SLIP-0048](slip-0048.md) | Deterministic key hierarchy for Graphene-based networks               | Standard      | Draft    |
+| [SLIP-0039](slip-0039.md) | Shamir's Secret-Sharing for Mnemonic Codes                            | Standard      | Final    |
+| [SLIP-0044](slip-0044.md) | Registered coin types for BIP-0044                                    | Standard      | Active   |
+| [SLIP-0048](slip-0048.md) | Deterministic key hierarchy for Graphene-based networks               | Standard      | Active   |
 | [SLIP-0077](slip-0077.md) | Deterministic blinding key derivation for Confidential Transactions   | Standard      | Draft    |
-| [SLIP-0132](slip-0132.md) | Registered HD version bytes for BIP-0032                              | Standard      | Draft    |
-| [SLIP-0173](slip-0173.md) | Registered human-readable parts for BIP-0173                          | Standard      | Draft    |
+| [SLIP-0132](slip-0132.md) | Registered HD version bytes for BIP-0032                              | Standard      | Active   |
+| [SLIP-0173](slip-0173.md) | Registered human-readable parts for BIP-0173                          | Standard      | Active   |
 
 ---
 

--- a/slip-0010.md
+++ b/slip-0010.md
@@ -4,7 +4,7 @@
 Number:  SLIP-0010
 Title:   Universal private key derivation from master private key
 Type:    Standard
-Status:  Draft
+Status:  Final
 Authors: Jochen Hoenicke <hoenicke@gmail.com>
          Pavol Rusnak <stick@satoshilabs.com>
 Created: 2016-04-26

--- a/slip-0011.md
+++ b/slip-0011.md
@@ -4,7 +4,7 @@
 Number:  SLIP-0011
 Title:   Symmetric encryption of key-value pairs using deterministic hierarchy
 Type:    Standard
-Status:  Draft
+Status:  Final
 Authors: Pavol Rusnak <stick@satoshilabs.com>
          Marek Palatinus <slush@satoshilabs.com>
          Karel Bilek <kb@karelbilek.com>

--- a/slip-0013.md
+++ b/slip-0013.md
@@ -4,7 +4,7 @@
 Number:  SLIP-0013
 Title:   Authentication using deterministic hierarchy
 Type:    Standard
-Status:  Draft
+Status:  Final
 Authors: Pavol Rusnak <stick@satoshilabs.com>
 Created: 2015-03-12
 ```

--- a/slip-0014.md
+++ b/slip-0014.md
@@ -4,7 +4,7 @@
 Number:  SLIP-0014
 Title:   Stress Test Deterministic Wallet
 Type:    Informational
-Status:  Draft
+Status:  Active
 Authors: Pavol Rusnak <stick@satoshilabs.com>
 Created: 2015-01-12
 ```

--- a/slip-0015.md
+++ b/slip-0015.md
@@ -4,7 +4,7 @@
 Number:  SLIP-0015
 Title:   Format for Bitcoin metadata and its encryption in HD wallets
 Type:    Standard
-Status:  Draft
+Status:  Final
 Authors: Karel Bilek <kb@karelbilek.com>
 Created: 2015-01-12
 ```

--- a/slip-0016.md
+++ b/slip-0016.md
@@ -4,7 +4,7 @@
 Number:  SLIP-0016
 Title:   Format for password storage and its encryption
 Type:    Standard
-Status:  Draft
+Status:  Final
 Authors: Peter Jensen <peteritsjustadream@gmail.com>
 Created: 2016-18-02
 ```

--- a/slip-0017.md
+++ b/slip-0017.md
@@ -4,7 +4,7 @@
 Number:  SLIP-0017
 Title:   ECDH using deterministic hierarchy
 Type:    Standard
-Status:  Draft
+Status:  Final
 Authors: Roman Zeyde <roman.zeyde@gmail.com>
 Created: 2016-05-29
 ```

--- a/slip-0019.md
+++ b/slip-0019.md
@@ -4,7 +4,7 @@
 Number:  SLIP-0019
 Title:   Proof of Ownership
 Type:    Standard
-Status:  Draft
+Status:  Accepted
 Authors: Andrew Kozlik <andrew.kozlik@satoshilabs.com>
          Stepan Snigirev <stepan@cryptoadvance.io>
          Ondrej Vejpustek <ondrej.vejpustek@satoshilabs.com>

--- a/slip-0021.md
+++ b/slip-0021.md
@@ -4,7 +4,7 @@
 Number:  SLIP-0021
 Title:   Hierarchical derivation of symmetric keys
 Type:    Standard
-Status:  Draft
+Status:  Final
 Authors: Andrew R. Kozlik <andrew.kozlik@satoshilabs.com>
          Ondrej Vejpustek <ondrej.vejpustek@satoshilabs.com>
          Pavol Rusnak <stick@satoshilabs.com>

--- a/slip-0022.md
+++ b/slip-0022.md
@@ -4,7 +4,7 @@
 Number:  SLIP-0022
 Title:   FIDO2 credential ID format for HD wallets
 Type:    Standard
-Status:  Draft
+Status:  Final
 Authors: Andrew R. Kozlik <andrew.kozlik@satoshilabs.com>
          Pavol Rusnak <stick@satoshilabs.com>
          Ondrej Vejpustek <ondrej.vejpustek@satoshilabs.com>

--- a/slip-0023.md
+++ b/slip-0023.md
@@ -4,7 +4,7 @@
 Number:  SLIP-0023
 Title:   Cardano HD master node derivation from a master seed
 Type:    Standard
-Status:  Draft
+Status:  Final
 Authors: Andrew R. Kozlik <andrew.kozlik@satoshilabs.com>
 Created: 2019-07-24
 ```

--- a/slip-0039.md
+++ b/slip-0039.md
@@ -4,7 +4,7 @@
 Number:  SLIP-0039
 Title:   Shamir's Secret-Sharing for Mnemonic Codes
 Type:    Standard
-Status:  Draft
+Status:  Final
 Authors: Pavol Rusnak <stick@satoshilabs.com>
          Andrew Kozlik <andrew.kozlik@satoshilabs.com>
          Ondrej Vejpustek <ondrej.vejpustek@satoshilabs.com>

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -4,7 +4,7 @@
 Number:  SLIP-0044
 Title:   Registered coin types for BIP-0044
 Type:    Standard
-Status:  Draft
+Status:  Active
 Authors: Pavol Rusnak <stick@satoshilabs.com>
          Marek Palatinus <slush@satoshilabs.com>
 Created: 2014-07-09
@@ -622,7 +622,7 @@ index | hexa       | symbol | coin
 591   | 0x8000024f | RNL    | [RentalChain](https://rentalchain.net/)
 592   | 0x80000250 | GRIN   | [Grin](https://grin.mw/)
 593   | 0x80000251 | MWC    | [MimbleWimbleCoin](https://www.mwc.mw/)
-594   | 0x80000252 | DOCK   | [Dock][https://dock.io]
+594   | 0x80000252 | DOCK   | [Dock](https://dock.io/)
 595   | 0x80000253 | POLYX  | [Polymesh](https://polymath.network/)
 596   | 0x80000254 | DIVER  | [Divergenti](https://www.divergenti.cl/)
 597   | 0x80000255 | XEP    | [Electra Protocol](https://www.electraprotocol.com/)

--- a/slip-0048.md
+++ b/slip-0048.md
@@ -4,7 +4,7 @@
 Number:  SLIP-0048
 Title:   Deterministic key hierarchy for Graphene-based networks
 Type:    Standard
-Status:  Draft
+Status:  Active
 Authors: Fabian Schuh <Fabian@chainsquad.com>
 Created: 2016-10-18
 ```

--- a/slip-0132.md
+++ b/slip-0132.md
@@ -4,7 +4,7 @@
 Number:  SLIP-0132
 Title:   Registered HD version bytes for BIP-0032
 Type:    Standard
-Status:  Draft
+Status:  Active
 Authors: Clark Moody <clark@clarkmoody.com>
 Created: 2018-02-08
 ```

--- a/slip-0173.md
+++ b/slip-0173.md
@@ -4,7 +4,7 @@
 Number:  SLIP-0173
 Title:   Registered human-readable parts for BIP-0173
 Type:    Standard
-Status:  Draft
+Status:  Active
 Authors: Clark Moody <clark@clarkmoody.com>
 Created: 2017-05-17
 ```


### PR DESCRIPTION
Right now all SLIPs are in Draft state, which can cause confusion. Furthermore people might then propose breaking changes to specifications that we consider final. I went through the SLIPs and set the status of each one according to what I believe is currently correct. This is the policy I used:
- **Draft**: The specification is either not finished or is not implemented yet and may still change.
- **Accepted**: The specification is implemented but not used in the field yet or at least not widely used. Changes to the specification would not cause compatibility issues or other disruption to users.
- **Active**: The specification is in effect, but is subject to amendments and is never meant to be completed, e.g. SLIP-0044 coin types.
- **Final**: Specification is widely deployed in the field. Changes to the specification are generally not acceptable, because they would likely lead to compatibility issues or cause inability to access user funds or login credentials.

I wasn't absolutely sure about SLIP-32, 48, 132 and 173, please have a look at those statuses. I think SLIP-77 isn't implemented yet so I left it in Draft even though we don't expect any changes.
