### PR TITLE
Update CRO (Crypto.org Chain) information in slip-44 coin list

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -422,7 +422,7 @@ index | hexa       | symbol | coin
 391   | 0x80000187 | LHD    | [LitecoinHD](https://ltchd.io)
 392   | 0x80000188 | CENNZ  | [CENNZnet](https://centrality.ai)
 393   | 0x80000189 | HSN    | [Hyper Speed Network](https://www.hsn.link/)
-394   | 0x8000018a | CRO    | [Crypto.com Chain](https://github.com/crypto-com/chain)
+394   | 0x8000018a | CRO    | [Crypto.org Chain](https://crypto.org)
 395   | 0x8000018b | UMBRU  | [Umbru](https://umbru.io)
 396   | 0x8000018c | TON    | [Free TON](https://freeton.org/)
 397   | 0x8000018d | NEAR   | [NEAR Protocol](https://nearprotocol.com/)


### PR DESCRIPTION
Following the updates on https://blog.crypto.com/cro-mainnet-launching-on-march-25th-2021-as-crypto-org-chain/

Crypto.com Chain is renamed as Crypto.org Chain with the new website URL: https://crypto.org

This PR updates the coin list in the slip-44 documents to cover it.