### PR TITLE
Update CRO (Crypto.org Chain) information in slip-0173 coin list

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -37,7 +37,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | [Blacknet](https://blacknet.ninja/)            | `blacknet` |         | `rblacknet` |
 | [CPUchain](https://cpuchain.org)               | `cpu`      | `tcpu`  | `rcpu`      |
 | [CranePay](https://cranepay.io/)               | `cp`       | `cpt`   | `cpr`       |
-| [Crypto.com Chain](https://crypto.com/chain)   | `cro`      | `tcro`  | `dcro`      |
+| [Crypto.org Chain](https://crypto.org)         | `cro`      | `tcro`  |             |
 | [DigiByte](https://www.digibyte.io/)           | `dgb`      | `dgbt`  | `dgbrt`     |
 | [FujiCoin](http://www.fujicoin.org/)           | `fc`       | `tf`    | `fcrt`      |
 | [Groestlcoin](https://groestlcoin.org/)        | `grs`      | `tgrs`  | `grsrt`     |


### PR DESCRIPTION
Following https://github.com/satoshilabs/slips/pull/1083, this PR further updates the entry in slip-0173.