### PR TITLE
add TxRef's HRPs from BIP-136 to SLIP-173

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -68,6 +68,14 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | [Zen Protocol](https://zenprotocol.com/)       | `zen`      | `tzn`   |             |
 | [Zilliqa](https://zilliqa.com/)                | `zil`      | `tzil`  |             |
 
+
+These are the registered human-readable parts for usage in Bech32 encoding for other purposes:
+
+| Project / Standard                                                       | Mainnet    | Testnet | Regtest     |
+| ------------------------------------------------------------------------ | ---------- | ------- | ----------- |
+| [TxRef](https://github.com/bitcoin/bips/blob/master/bip-0136.mediawiki)  | `tx`       | `txtest`| `txrt`      |
+
+
 ## Libraries
 
 * [Reference Implementations](https://github.com/sipa/bech32/tree/master/ref)


### PR DESCRIPTION
This adds HRP's that are used in BIP-136 to SLIP-173. I have created a new section as our use does not relate to witness programs. Please let me know if you feel this isn't a good way of organizing things.