### PR TITLE
Fixed 10291 slip-0044 to XRC and changed to correct domain

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1133,7 +1133,7 @@ index | hexa       | symbol | coin
 9999  | 0x8000270f | GOD    | [Bitcoin God](https://www.bitcoingod.org)
 10000 | 0x80002710 | FO     | [FIBOS](https://fibos.io/)
 10226 | 0x800027f2 | RTM    | [Raptoreum](https://raptoreum.com/)
-10291 | 0x80002833 | BTR    | [Bitcoin Rhodium](https://www.bitcoinrh.org)
+10291 | 0x80002833 | XRC    | [XRhodium](https://www.xrhodium.org)
 11111 | 0x80002b67 | ESS    | [Essentia One](https://essentia.one/)
 12345 | 0x80003039 | IPOS   | [IPOS](https://iposlab.com)
 12586 | 0x8000312a | MINA   | [Mina](https://minaprotocol.com/)


### PR DESCRIPTION
Bitcoin Rhodium (BTR) was rebranded to XRhodium (XRC). 

Project have a new domain www.xrhodium.org.