### PR TITLE
SLIP44: Clarify difference between coin type and path component column

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -26,7 +26,7 @@ These are the registered coin types for usage in level 2 of BIP44 described in c
 
 All these constants are used as hardened derivation.
 
-index | hexa       | symbol | coin
+Coin type | Path component (`coin_type'`) | Symbol | Coin
 ------|------------|--------|-----------------------------------
 0     | 0x80000000 | BTC    | [Bitcoin](https://bitcoin.org/)
 1     | 0x80000001 |        | Testnet (all coins)


### PR DESCRIPTION
Before the titles gave the impression that a decimal and a hexa representation of the same thing is listed. However, this is not the case. The first column is the `coin_type` in the range 0–2**31-1 and the second column as the resulting hardened path component with the high bit set (`coin_type XOR 0x80000000`).