### PR TITLE
eCash rebranding

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -927,7 +927,7 @@ Coin type | Path component (`coin_type'`) | Symbol | Coin
 896   | 0x80000380 | LKSC   | [LKSCoin](https://www.lkschain.io/)
 897   | 0x80000381 |        |
 898   | 0x80000382 |        |
-899   | 0x80000383 | BCHA   | [BCHA](https://www.bitcoinabc.org/)
+899   | 0x80000383 | XEC    | [eCash](https://e.cash/)
 900   | 0x80000384 | LMO    | [Lumeneo](https://lumeneo.network/)
 901   | 0x80000385 |        |
 902   | 0x80000386 |        |
@@ -1062,7 +1062,7 @@ Coin type | Path component (`coin_type'`) | Symbol | Coin
 1784  | 0x800006F8 | JPYS   | [JPY Stablecoin](https://settlenet.io/)
 1815  | 0x80000717 | ADA    | [Cardano](https://www.cardanohub.org/en/home/)
 1856  | 0x80000743 | TES    | [Teslacoin](https://www.tesla-coin.com/)
-1899  | 0x8000076b | SLPA   | [BCHA token](https://www.bitcoinabc.org)
+1899  | 0x8000076b | XEC    | [eCash token](https://e.cash/)
 1901  | 0x8000076d | CLC    | [Classica](https://github.com/classica/)
 1919  | 0x8000077f | VIPS   | [VIPSTARCOIN](https://www.vipstarcoin.jp/)
 1926  | 0x80000786 | CITY   | [City Coin](https://city-chain.org/)


### PR DESCRIPTION
BCHA will be rebranded eCash on July 1st 2021.

You can find public information about this on Bitcoin ABC's blog https://blog.bitcoinabc.org/2021/06/28/ecash-wealth-redefined/
> Here’s some of what’s happening:
> - On July 1, 2021 at 12:00 noon UTC, Bitcoin Cash ABC (BCHA) will rebrand to eCash (XEC).
> - ...
> - A new website will be launched at e.cash.