### PR TITLE
Register Biblepay

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1059,6 +1059,7 @@ Coin type | Path component (`coin_type'`) | Symbol | Coin
 1688  | 0x80000698 | BCX    | [BitcoinX](https://bcx.org)
 1729  | 0x800006c1 | XTZ    | [Tezos](https://tezos.com)
 1776  | 0x800006f0 | LBTC   | [Liquid BTC](https://blockstream.com/liquid/)
+1777  | 0x800006f1 | BBP    | [Biblepay](https://www.biblepay.org/)
 1784  | 0x800006F8 | JPYS   | [JPY Stablecoin](https://settlenet.io/)
 1815  | 0x80000717 | ADA    | [Cardano](https://www.cardanohub.org/en/home/)
 1856  | 0x80000743 | TES    | [Teslacoin](https://www.tesla-coin.com/)


### PR DESCRIPTION
https://www.biblepay.org/
Biblepay Core wallet is a Dash 0.16 fork so it supports BIP044 HD wallets.