### PR TITLE
Adding Sora Network with coins XOR, VAL, PSWAP

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -643,7 +643,7 @@ Coin type | Path component (`coin_type'`) | Symbol | Coin
 612   | 0x80000264 |        | [Calamari Network Private Asset](https://calamari.manta.network/)
 613   | 0x80000265 | WCN    | [Widecoin](https://Widecoin.org/)
 614   | 0x80000266 |        |
-615   | 0x80000267 | PSWAP  | [PolkaSwap](https://sora.org/soratokens) [https://polkaswap.io]
+615   | 0x80000267 | PSWAP  | [PolkaSwap](https://polkaswap.io)
 616   | 0x80000268 | VAL    | [Validator](https://sora.org/soratokens)
 617   | 0x80000269 | XOR    | [Sora](https://sora.org/soratokens)
 618   | 0x8000026a | SSP    | [SmartShare](http://www.smartshare.vip/)

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -643,9 +643,9 @@ Coin type | Path component (`coin_type'`) | Symbol | Coin
 612   | 0x80000264 |        | [Calamari Network Private Asset](https://calamari.manta.network/)
 613   | 0x80000265 | WCN    | [Widecoin](https://Widecoin.org/)
 614   | 0x80000266 |        |
-615   | 0x80000267 |        |
-616   | 0x80000268 |        |
-617   | 0x80000269 |        |
+615   | 0x80000267 | PSWAP  | [PolkaSwap](https://sora.org/soratokens) [https://polkaswap.io]
+616   | 0x80000268 | VAL    | [Validator](https://sora.org/soratokens)
+617   | 0x80000269 | XOR    | [Sora](https://sora.org/soratokens)
 618   | 0x8000026a | SSP    | [SmartShare](http://www.smartshare.vip/)
 619   | 0x8000026b | DEI    | [DeimosX](https://deimosx.org/)
 620   | 0x8000026c |        |


### PR DESCRIPTION
We are developing a Sora ledger app and would like this included soon. 

Sora Network, a substrate based blockchain, has 1 coin and 2 tokens.  1 coin is the operator coin, XOR.  PSWAP and VAL are reward tokens.   We would like them to have hardened BIP-0044 references.   Thank you!

https://sora.org
https://sora.org/soratokens
https://polkaswap.io