### PR TITLE
Add Cosmos Ecosystem chains to SLIP 173

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -21,86 +21,85 @@ The BIP repository does not want to deal with assigning the values for various c
 
 These are the registered human-readable parts for usage in Bech32 encoding of witness programs.
 
-| Coin                                           | Mainnet       | Testnet | Regtest     |
-| ---------------------------------------------- | ------------- | ------- | ----------- |
-| [Agoric](https://agoric.com/)                  | `agoric`      |         |             |
-| [Akash Network](https://akash.network/)        | `akash`       |         |             |
-| [Alaya](https://alaya.network/)                | `atp`         | `atx`   |             |
-| [Althea](https://althea.net/)                  | `althea`      |         |             |
-| [BARE](https://bare.network)                   | `bare`        | `tbare` | `bart`      |
-| [Band Protocol](https://bandprotocol.com/)     | `band`        |         |             |
-| [Bellcoin](https://bellcoin.web4u.jp/)         | `bm`          | `bt`    | `br`        |
-| [Binance Chain](https://docs.binance.org/)     | `bnb`         |         |             |
-| [Bitcoin](https://bitcoin.org/)                | `bc`          | `tb`    | `bcrt`      |
-| [Bitcoin Atom](https://bitcoinatom.io/)        | `bca`         | `tbca`  | `bcart`     |
-| [Bitcoin Gold](https://bitcoingold.org/)       | `btg`         | `tbtg`  |             |
-| [Bitcoin Platinum](https://btcplt.org/)        | `btp`         | `tbtp`  |             |
-| [Bitcoin Post-Quantum](https://bitcoinpq.org/) | `pq`          | `tq`    | `pqrt`      |
-| [Bitcoin Private](https://btcprivate.org/)     | `btcp`        | `tbtcp` | `regbtcp`   |
-| [Bitcore](https://bitcore.cc/)                 | `btx`         | `tbtx`  |             |
-| [Bitsong](https://bitsong.io/)                 | `bitsong`     |         |             |
-| [BitZeny](https://bitzeny.tech/)               | `bz`          | `tz`    | `rz`        |
-| [Blacknet](https://blacknet.ninja/)            | `blacknet`    |         | `rblacknet` |
-| [CertiK Chain](https://www.certik.org/about)   | `certik`      |         |             |
-| [Cosmos Hub](https://cosmos.network/)          | `cosmos`      |         |             |
-| [CPUchain](https://cpuchain.org)               | `cpu`         | `tcpu`  | `rcpu`      |
-| [CranePay](https://cranepay.io/)               | `cp`          | `cpt`   | `cpr`       |
-| [Crypto.org Chain](https://crypto.org)         | `cro`         | `tcro`  |             |
-| [Cyber](https://cybercongress.ai/)             | `cyber`       |         |             |
-| [Desmos](https://www.desmos.network/)          | `desmos`      |         |             |
-| [DigiByte](https://www.digibyte.io/)           | `dgb`         | `dgbt`  | `dgbrt`     |
-| [e-Money](https://www.e-money.com/)            | `emoney`      |         |             |
-| [fetch.ai](https://fetch.ai/)                  | `fetch`       |         |             |
-| [FujiCoin](http://www.fujicoin.org/)           | `fc`          | `tf`    | `fcrt`      |
-| [Groestlcoin](https://groestlcoin.org/)        | `grs`         | `tgrs`  | `grsrt`     |
-| [Handshake](https://handshake.org/)            | `hs`          | `ts`    | `rs`        |
-| [Injective](https://injectiveprotocol.com/)    | `inj`         |         |             |
-| [IoTeX](https://www.iotex.io/)                 | `io`          | `it`    |             |
-| [IRISnet](https://irisnet.org/)                | `iris`        |         |             |
-| [Juno](https://junochain.com/)                 | `juno`        |         |             |
-| [Kava](https://www.kava.io/)                   | `kava`        |         |             |
-| [KiChain](https://foundation.ki/)              | `ki`          |         |             |
-| [Kira Network](https://kira.network/)          | `kira`        |         |             |
-| [LatticeX](https://latticex.foundation/)       | `pla`         | `plt`   |             |
-| [Likecoin](https://like.co/)                   | `cosmos`      |         |             |
-| [Litecoin](https://litecoin.org/)              | `ltc`         | `tltc`  | `rltc`      |
-| [Medibloc](https://medibloc.com/en/)           | `panacea`     |         |             |
-| [Microtick](https://microtick.com/)            | `micro`       |         |             |
-| [Monacoin](https://monacoin.org/)              | `mona`        | `tmona` | `rmona`     |
-| [Myriad](https://myriadcoin.org/)              | `my`          | `tm`    |             |
-| [Namecoin](https://www.namecoin.org/)          | `nc`          | `tn`    | `ncrt`      |
-| [Oasis Network](https://oasisprotocol.org/)    | `oasis`       | `oasis` |             |
-| [OKExChain](https://www.okex.com/okexchain)    | `ex`          |         |             |
-| [Omni](https://www.omnilayer.org)              | `o`           | `to`    | `ocrt`      |
-| [Osmosis](https://osmosis.zone)                | `osmo`        |         |             |
-| [Peercoin](https://www.peercoin.net)           | `xpc`         | `tpc`   |             |
-| [Persistence](https://persistence.one/)        | `persistence` |         |             |
-| [PKT](https://github.com/pkt-cash/pktd)        | `pkt`         | `tpk`   |             |
-| [PlatON](https://platon.network/)              | `lat`         | `lax`   |             |
-| [Quantum Resistant Ledger](https://theqrl.org) | `qrl`         | `tqrl`  | `qrlrt`     |
-| [Ravencoin](https://ravencoin.org/)            | `rc`          | `tr`    | `rcrt`      |
-| [Regen](https://www.regen.network/)            | `regen`       |         |             |
-| [Riecoin](https://riecoin.dev/)                | `ric`         | `tric`  | `rric`      |
-| [Secret Network](https://scrt.network/)        | `secret`      |         |             |
-| [Sentinel](https://sentinel.co/)               | `sent`        |         |             |
-| [Sifchain](https://sifchain.finance/)          | `sif`         |         |             |
-| [Stargaze](https://stargaze.zone/)             | `stars`       |         |             |
-| [Starname](https://www.starname.me/)           | `star`        |         |             |
-| [Straightedge](http://straighted.ge/)          | `str`         |         |             |
-| [Switcheo](https://www.switcheo.com/)          | `swth`        |         |             |
-| [Sugarchain](https://sugarchain.org/)          | `sugar`       | `tugar` | `rugar`     |
-| [Susucoin](https://www.susukino.com/)          | `susu`        | `tutu`  | `ruru`      |
-| [Syscoin](https://syscoin.org/)                | `sys`         | `tsys`  | `scrt`      |
-| [Terra](https://terra.money/)                  | `terra`       |         |             |
-| [Tgrade](https://tgrade.finance/)              | `tgrade`      |         |             |
-| [Thorchain](https://thorchain.org/)            | `thor`        |         |             |
-| [Unit-e](https://dtr.org/unit-e/)              | `ue`          | `tue`   | `uert`      |
-| [Vertcoin](https://vertcoin.org/)              | `vtc`         | `tvtc`  |             |
-| [Viacoin](https://viacoin.org/)                | `via`         | `tvia`  |             |
-| [VIPSTARCOIN](https://www.vipstarcoin.jp/)     | `vips`        | `tvips` |             |
-| [YeeCo](https://www.yeeco.io/)                 | `yee`         | `tyee`  |             |
-| [Zen Protocol](https://zenprotocol.com/)       | `zen`         | `tzn`   |             |
-| [Zilliqa](https://zilliqa.com/)                | `zil`         | `tzil`  |             |
+| Coin                                           | Mainnet    | Testnet | Regtest     |
+| ---------------------------------------------- | ---------- | ------- | ----------- |
+| [Agoric](https://agoric.com/)                  | `agoric`   |         |             |
+| [Akash Network](https://akash.network/)        | `akash`    |         |             |
+| [Alaya](https://alaya.network/)                | `atp`      | `atx`   |             |
+| [Althea](https://althea.net/)                  | `althea`   |         |             |
+| [BARE](https://bare.network)                   | `bare`     | `tbare` | `bart`      |
+| [Band Protocol](https://bandprotocol.com/)     | `band`     |         |             |
+| [Bellcoin](https://bellcoin.web4u.jp/)         | `bm`       | `bt`    | `br`        |
+| [Binance Chain](https://docs.binance.org/)     | `bnb`      |         |             |
+| [Bitcoin](https://bitcoin.org/)                | `bc`       | `tb`    | `bcrt`      |
+| [Bitcoin Atom](https://bitcoinatom.io/)        | `bca`      | `tbca`  | `bcart`     |
+| [Bitcoin Gold](https://bitcoingold.org/)       | `btg`      | `tbtg`  |             |
+| [Bitcoin Platinum](https://btcplt.org/)        | `btp`      | `tbtp`  |             |
+| [Bitcoin Post-Quantum](https://bitcoinpq.org/) | `pq`       | `tq`    | `pqrt`      |
+| [Bitcoin Private](https://btcprivate.org/)     | `btcp`     | `tbtcp` | `regbtcp`   |
+| [Bitcore](https://bitcore.cc/)                 | `btx`      | `tbtx`  |             |
+| [Bitsong](https://bitsong.io/)                 | `bitsong`  |         |             |
+| [BitZeny](https://bitzeny.tech/)               | `bz`       | `tz`    | `rz`        |
+| [Blacknet](https://blacknet.ninja/)            | `blacknet` |         | `rblacknet` |
+| [CertiK Chain](https://www.certik.org/about)   | `certik`   |         |             |
+| [Cosmos Hub](https://cosmos.network/)          | `cosmos`   |         |             |
+| [CPUchain](https://cpuchain.org)               | `cpu`      | `tcpu`  | `rcpu`      |
+| [CranePay](https://cranepay.io/)               | `cp`       | `cpt`   | `cpr`       |
+| [Crypto.org Chain](https://crypto.org)         | `cro`      | `tcro`  |             |
+| [Cyber](https://cybercongress.ai/)             | `cyber`    |         |             |
+| [Desmos](https://www.desmos.network/)          | `desmos`   |         |             |
+| [DigiByte](https://www.digibyte.io/)           | `dgb`      | `dgbt`  | `dgbrt`     |
+| [e-Money](https://www.e-money.com/)            | `emoney`   |         |             |
+| [fetch.ai](https://fetch.ai/)                  | `fetch`    |         |             |
+| [FujiCoin](http://www.fujicoin.org/)           | `fc`       | `tf`    | `fcrt`      |
+| [Groestlcoin](https://groestlcoin.org/)        | `grs`      | `tgrs`  | `grsrt`     |
+| [Handshake](https://handshake.org/)            | `hs`       | `ts`    | `rs`        |
+| [Injective](https://injectiveprotocol.com/)    | `inj`      |         |             |
+| [IoTeX](https://www.iotex.io/)                 | `io`       | `it`    |             |
+| [IRISnet](https://irisnet.org/)                | `iris`     |         |             |
+| [Juno](https://junochain.com/)                 | `juno`     |         |             |
+| [Kava](https://www.kava.io/)                   | `kava`     |         |             |
+| [KiChain](https://foundation.ki/)              | `ki`       |         |             |
+| [Kira Network](https://kira.network/)          | `kira`     |         |             |
+| [LatticeX](https://latticex.foundation/)       | `pla`      | `plt`   |             |
+| [Likecoin](https://like.co/)                   | `cosmos`   |         |             |
+| [Litecoin](https://litecoin.org/)              | `ltc`      | `tltc`  | `rltc`      |
+| [Medibloc](https://medibloc.com/en/)           | `panacea`  |         |             |
+| [Microtick](https://microtick.com/)            | `micro`    |         |             |
+| [Monacoin](https://monacoin.org/)              | `mona`     | `tmona` | `rmona`     |
+| [Myriad](https://myriadcoin.org/)              | `my`       | `tm`    |             |
+| [Namecoin](https://www.namecoin.org/)          | `nc`       | `tn`    | `ncrt`      |
+| [Oasis Network](https://oasisprotocol.org/)    | `oasis`    | `oasis` |             |
+| [OKExChain](https://www.okex.com/okexchain)    | `ex`       |         |             |
+| [Omni](https://www.omnilayer.org)              | `o`        | `to`    | `ocrt`      |
+| [Osmosis](https://osmosis.zone)                | `osmo`     |         |             |
+| [Peercoin](https://www.peercoin.net)           | `xpc`      | `tpc`   |             |
+| [PKT](https://github.com/pkt-cash/pktd)        | `pkt`      | `tpk`   |             |
+| [PlatON](https://platon.network/)              | `lat`      | `lax`   |             |
+| [Quantum Resistant Ledger](https://theqrl.org) | `qrl`      | `tqrl`  | `qrlrt`     |
+| [Ravencoin](https://ravencoin.org/)            | `rc`       | `tr`    | `rcrt`      |
+| [Regen](https://www.regen.network/)            | `regen`    |         |             |
+| [Riecoin](https://riecoin.dev/)                | `ric`      | `tric`  | `rric`      |
+| [Secret Network](https://scrt.network/)        | `secret`   |         |             |
+| [Sentinel](https://sentinel.co/)               | `sent`     |         |             |
+| [Sifchain](https://sifchain.finance/)          | `sif`      |         |             |
+| [Stargaze](https://stargaze.zone/)             | `stars`    |         |             |
+| [Starname](https://www.starname.me/)           | `star`     |         |             |
+| [Straightedge](http://straighted.ge/)          | `str`      |         |             |
+| [Switcheo](https://www.switcheo.com/)          | `swth`     |         |             |
+| [Sugarchain](https://sugarchain.org/)          | `sugar`    | `tugar` | `rugar`     |
+| [Susucoin](https://www.susukino.com/)          | `susu`     | `tutu`  | `ruru`      |
+| [Syscoin](https://syscoin.org/)                | `sys`      | `tsys`  | `scrt`      |
+| [Terra](https://terra.money/)                  | `terra`    |         |             |
+| [Tgrade](https://tgrade.finance/)              | `tgrade`   |         |             |
+| [Thorchain](https://thorchain.org/)            | `thor`     |         |             |
+| [Unit-e](https://dtr.org/unit-e/)              | `ue`       | `tue`   | `uert`      |
+| [Vertcoin](https://vertcoin.org/)              | `vtc`      | `tvtc`  |             |
+| [Viacoin](https://viacoin.org/)                | `via`      | `tvia`  |             |
+| [VIPSTARCOIN](https://www.vipstarcoin.jp/)     | `vips`     | `tvips` |             |
+| [YeeCo](https://www.yeeco.io/)                 | `yee`      | `tyee`  |             |
+| [Zen Protocol](https://zenprotocol.com/)       | `zen`      | `tzn`   |             |
+| [Zilliqa](https://zilliqa.com/)                | `zil`      | `tzil`  |             |
 
 ## Libraries
 

--- a/slip-0173.md
+++ b/slip-0173.md
@@ -43,7 +43,6 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | [Blacknet](https://blacknet.ninja/)            | `blacknet`    |         | `rblacknet` |
 | [CertiK Chain](https://www.certik.org/about)   | `certik`      |         |             |
 | [Cosmos Hub](https://cosmos.network/)          | `cosmos`      |         |             |
-| [Cosmos Hub](https://cosmos.network/)          | `cosmos`      |         |             |
 | [CPUchain](https://cpuchain.org)               | `cpu`         | `tcpu`  | `rcpu`      |
 | [CranePay](https://cranepay.io/)               | `cp`          | `cpt`   | `cpr`       |
 | [Crypto.org Chain](https://crypto.org)         | `cro`         | `tcro`  |             |

--- a/slip-0173.md
+++ b/slip-0173.md
@@ -21,87 +21,87 @@ The BIP repository does not want to deal with assigning the values for various c
 
 These are the registered human-readable parts for usage in Bech32 encoding of witness programs.
 
-| Coin                                              | Mainnet       | Testnet | Regtest     |
-| ------------------------------------------------- | ------------- | ------- | ----------- |
-| [Agoric](https://agoric.com/)                     | `agoric`      |         |             |
-| [Akash Network](https://akash.network/)           | `akash`       |         |             |
-| [Alaya](https://alaya.network/)                   | `atp`         | `atx`   |             |
-| [Althea](https://althea.net/)                     | `althea`      |         |             |
-| [BARE](https://bare.network)                      | `bare`        | `tbare` | `bart`      |
-| [Band Protocol](https://bandprotocol.com/)        | `band`        |         |             |
-| [Bellcoin](https://bellcoin.web4u.jp/)            | `bm`          | `bt`    | `br`        |
-| [Binance Chain](https://docs.binance.org/)        | `bnb`         |         |             |
-| [Bitcoin](https://bitcoin.org/)                   | `bc`          | `tb`    | `bcrt`      |
-| [Bitcoin Atom](https://bitcoinatom.io/)           | `bca`         | `tbca`  | `bcart`     |
-| [Bitcoin Gold](https://bitcoingold.org/)          | `btg`         | `tbtg`  |             |
-| [Bitcoin Platinum](https://btcplt.org/)           | `btp`         | `tbtp`  |             |
-| [Bitcoin Post-Quantum](https://bitcoinpq.org/)    | `pq`          | `tq`    | `pqrt`      |
-| [Bitcoin Private](https://btcprivate.org/)        | `btcp`        | `tbtcp` | `regbtcp`   |
-| [Bitcore](https://bitcore.cc/)                    | `btx`         | `tbtx`  |             |
-| [Bitsong](https://bitsong.io/)                    | `bitsong`     |         |             |
-| [BitZeny](https://bitzeny.tech/)                  | `bz`          | `tz`    | `rz`        |
-| [Blacknet](https://blacknet.ninja/)               | `blacknet`    |         | `rblacknet` |
-| [CertiK Chain](https://www.certik.org/technology) | `certik`      |         |             |
-| [Cosmos Hub](https://cosmos.network/)             | `cosmos`      |         |             |
-| [Cosmos Hub](https://cosmos.network/)             | `cosmos`      |         |             |
-| [CPUchain](https://cpuchain.org)                  | `cpu`         | `tcpu`  | `rcpu`      |
-| [CranePay](https://cranepay.io/)                  | `cp`          | `cpt`   | `cpr`       |
-| [Crypto.org Chain](https://crypto.org)            | `cro`         | `tcro`  |             |
-| [Cyber](https://cybercongress.ai/)                | `cyber`       |         |             |
-| [Desmos](https://www.desmos.network/)             | `desmos`      |         |             |
-| [DigiByte](https://www.digibyte.io/)              | `dgb`         | `dgbt`  | `dgbrt`     |
-| [e-Money](https://www.e-money.com/)               | `emoney`      |         |             |
-| [fetch.ai](https://fetch.ai/)                     | `fetch`       |         |             |
-| [FujiCoin](http://www.fujicoin.org/)              | `fc`          | `tf`    | `fcrt`      |
-| [Groestlcoin](https://groestlcoin.org/)           | `grs`         | `tgrs`  | `grsrt`     |
-| [Handshake](https://handshake.org/)               | `hs`          | `ts`    | `rs`        |
-| [Injective](https://injectiveprotocol.com/)       | `inj`         |         |             |
-| [IoTeX](https://www.iotex.io/)                    | `io`          | `it`    |             |
-| [IRISnet](https://irisnet.org/)                   | `iris`        |         |             |
-| [Juno](https://junochain.com/)                    | `juno`        |         |             |
-| [Kava](https://www.kava.io/)                      | `kava`        |         |             |
-| [KiChain](https://foundation.ki/)                 | `ki`          |         |             |
-| [Kira Network](https://kira.network/)             | `kira`        |         |             |
-| [LatticeX](https://latticex.foundation/)          | `pla`         | `plt`   |             |
-| [Likecoin](https://like.co/)                      | `cosmos`      |         |             |
-| [Litecoin](https://litecoin.org/)                 | `ltc`         | `tltc`  | `rltc`      |
-| [Medibloc](https://medibloc.com/en/)              | `panacea`     |         |             |
-| [Microtick](https://microtick.com/)               | `micro`       |         |             |
-| [Monacoin](https://monacoin.org/)                 | `mona`        | `tmona` | `rmona`     |
-| [Myriad](https://myriadcoin.org/)                 | `my`          | `tm`    |             |
-| [Namecoin](https://www.namecoin.org/)             | `nc`          | `tn`    | `ncrt`      |
-| [Oasis Network](https://oasisprotocol.org/)       | `oasis`       | `oasis` |             |
-| [OKExChain](https://www.okex.com/okexchain)       | `ex`          |         |             |
-| [Omni](https://www.omnilayer.org)                 | `o`           | `to`    | `ocrt`      |
-| [Osmosis](https://osmosis.zone)                   | `osmo`        |         |             |
-| [Peercoin](https://www.peercoin.net)              | `xpc`         | `tpc`   |             |
-| [Persistence](https://persistence.one/)           | `persistence` |         |             |
-| [PKT](https://github.com/pkt-cash/pktd)           | `pkt`         | `tpk`   |             |
-| [PlatON](https://platon.network/)                 | `lat`         | `lax`   |             |
-| [Quantum Resistant Ledger](https://theqrl.org)    | `qrl`         | `tqrl`  | `qrlrt`     |
-| [Ravencoin](https://ravencoin.org/)               | `rc`          | `tr`    | `rcrt`      |
-| [Regen](https://www.regen.network/)               | `regen`       |         |             |
-| [Riecoin](https://riecoin.dev/)                   | `ric`         | `tric`  | `rric`      |
-| [Secret Network](https://scrt.network/)           | `secret`      |         |             |
-| [Sentinel](https://sentinel.co/)                  | `sent`        |         |             |
-| [Sifchain](https://sifchain.finance/)             | `sif`         |         |             |
-| [Stargaze](https://stargaze.zone/)                | `stars`       |         |             |
-| [Starname](https://www.starname.me/)              | `star`        |         |             |
-| [Straightedge](http://straighted.ge/)             | `str`         |         |             |
-| [Switcheo](https://www.switcheo.com/)             | `swth`        |         |             |
-| [Sugarchain](https://sugarchain.org/)             | `sugar`       | `tugar` | `rugar`     |
-| [Susucoin](https://www.susukino.com/)             | `susu`        | `tutu`  | `ruru`      |
-| [Syscoin](https://syscoin.org/)                   | `sys`         | `tsys`  | `scrt`      |
-| [Terra](https://terra.money/)                     | `terra`       |         |             |
-| [Tgrade](https://tgrade.finance/)                 | `tgrade`      |         |             |
-| [Thorchain](https://thorchain.org/)               | `thor`        |         |             |
-| [Unit-e](https://dtr.org/unit-e/)                 | `ue`          | `tue`   | `uert`      |
-| [Vertcoin](https://vertcoin.org/)                 | `vtc`         | `tvtc`  |             |
-| [Viacoin](https://viacoin.org/)                   | `via`         | `tvia`  |             |
-| [VIPSTARCOIN](https://www.vipstarcoin.jp/)        | `vips`        | `tvips` |             |
-| [YeeCo](https://www.yeeco.io/)                    | `yee`         | `tyee`  |             |
-| [Zen Protocol](https://zenprotocol.com/)          | `zen`         | `tzn`   |             |
-| [Zilliqa](https://zilliqa.com/)                   | `zil`         | `tzil`  |             |
+| Coin                                           | Mainnet       | Testnet | Regtest     |
+| ---------------------------------------------- | ------------- | ------- | ----------- |
+| [Agoric](https://agoric.com/)                  | `agoric`      |         |             |
+| [Akash Network](https://akash.network/)        | `akash`       |         |             |
+| [Alaya](https://alaya.network/)                | `atp`         | `atx`   |             |
+| [Althea](https://althea.net/)                  | `althea`      |         |             |
+| [BARE](https://bare.network)                   | `bare`        | `tbare` | `bart`      |
+| [Band Protocol](https://bandprotocol.com/)     | `band`        |         |             |
+| [Bellcoin](https://bellcoin.web4u.jp/)         | `bm`          | `bt`    | `br`        |
+| [Binance Chain](https://docs.binance.org/)     | `bnb`         |         |             |
+| [Bitcoin](https://bitcoin.org/)                | `bc`          | `tb`    | `bcrt`      |
+| [Bitcoin Atom](https://bitcoinatom.io/)        | `bca`         | `tbca`  | `bcart`     |
+| [Bitcoin Gold](https://bitcoingold.org/)       | `btg`         | `tbtg`  |             |
+| [Bitcoin Platinum](https://btcplt.org/)        | `btp`         | `tbtp`  |             |
+| [Bitcoin Post-Quantum](https://bitcoinpq.org/) | `pq`          | `tq`    | `pqrt`      |
+| [Bitcoin Private](https://btcprivate.org/)     | `btcp`        | `tbtcp` | `regbtcp`   |
+| [Bitcore](https://bitcore.cc/)                 | `btx`         | `tbtx`  |             |
+| [Bitsong](https://bitsong.io/)                 | `bitsong`     |         |             |
+| [BitZeny](https://bitzeny.tech/)               | `bz`          | `tz`    | `rz`        |
+| [Blacknet](https://blacknet.ninja/)            | `blacknet`    |         | `rblacknet` |
+| [CertiK Chain](https://www.certik.org/about)   | `certik`      |         |             |
+| [Cosmos Hub](https://cosmos.network/)          | `cosmos`      |         |             |
+| [Cosmos Hub](https://cosmos.network/)          | `cosmos`      |         |             |
+| [CPUchain](https://cpuchain.org)               | `cpu`         | `tcpu`  | `rcpu`      |
+| [CranePay](https://cranepay.io/)               | `cp`          | `cpt`   | `cpr`       |
+| [Crypto.org Chain](https://crypto.org)         | `cro`         | `tcro`  |             |
+| [Cyber](https://cybercongress.ai/)             | `cyber`       |         |             |
+| [Desmos](https://www.desmos.network/)          | `desmos`      |         |             |
+| [DigiByte](https://www.digibyte.io/)           | `dgb`         | `dgbt`  | `dgbrt`     |
+| [e-Money](https://www.e-money.com/)            | `emoney`      |         |             |
+| [fetch.ai](https://fetch.ai/)                  | `fetch`       |         |             |
+| [FujiCoin](http://www.fujicoin.org/)           | `fc`          | `tf`    | `fcrt`      |
+| [Groestlcoin](https://groestlcoin.org/)        | `grs`         | `tgrs`  | `grsrt`     |
+| [Handshake](https://handshake.org/)            | `hs`          | `ts`    | `rs`        |
+| [Injective](https://injectiveprotocol.com/)    | `inj`         |         |             |
+| [IoTeX](https://www.iotex.io/)                 | `io`          | `it`    |             |
+| [IRISnet](https://irisnet.org/)                | `iris`        |         |             |
+| [Juno](https://junochain.com/)                 | `juno`        |         |             |
+| [Kava](https://www.kava.io/)                   | `kava`        |         |             |
+| [KiChain](https://foundation.ki/)              | `ki`          |         |             |
+| [Kira Network](https://kira.network/)          | `kira`        |         |             |
+| [LatticeX](https://latticex.foundation/)       | `pla`         | `plt`   |             |
+| [Likecoin](https://like.co/)                   | `cosmos`      |         |             |
+| [Litecoin](https://litecoin.org/)              | `ltc`         | `tltc`  | `rltc`      |
+| [Medibloc](https://medibloc.com/en/)           | `panacea`     |         |             |
+| [Microtick](https://microtick.com/)            | `micro`       |         |             |
+| [Monacoin](https://monacoin.org/)              | `mona`        | `tmona` | `rmona`     |
+| [Myriad](https://myriadcoin.org/)              | `my`          | `tm`    |             |
+| [Namecoin](https://www.namecoin.org/)          | `nc`          | `tn`    | `ncrt`      |
+| [Oasis Network](https://oasisprotocol.org/)    | `oasis`       | `oasis` |             |
+| [OKExChain](https://www.okex.com/okexchain)    | `ex`          |         |             |
+| [Omni](https://www.omnilayer.org)              | `o`           | `to`    | `ocrt`      |
+| [Osmosis](https://osmosis.zone)                | `osmo`        |         |             |
+| [Peercoin](https://www.peercoin.net)           | `xpc`         | `tpc`   |             |
+| [Persistence](https://persistence.one/)        | `persistence` |         |             |
+| [PKT](https://github.com/pkt-cash/pktd)        | `pkt`         | `tpk`   |             |
+| [PlatON](https://platon.network/)              | `lat`         | `lax`   |             |
+| [Quantum Resistant Ledger](https://theqrl.org) | `qrl`         | `tqrl`  | `qrlrt`     |
+| [Ravencoin](https://ravencoin.org/)            | `rc`          | `tr`    | `rcrt`      |
+| [Regen](https://www.regen.network/)            | `regen`       |         |             |
+| [Riecoin](https://riecoin.dev/)                | `ric`         | `tric`  | `rric`      |
+| [Secret Network](https://scrt.network/)        | `secret`      |         |             |
+| [Sentinel](https://sentinel.co/)               | `sent`        |         |             |
+| [Sifchain](https://sifchain.finance/)          | `sif`         |         |             |
+| [Stargaze](https://stargaze.zone/)             | `stars`       |         |             |
+| [Starname](https://www.starname.me/)           | `star`        |         |             |
+| [Straightedge](http://straighted.ge/)          | `str`         |         |             |
+| [Switcheo](https://www.switcheo.com/)          | `swth`        |         |             |
+| [Sugarchain](https://sugarchain.org/)          | `sugar`       | `tugar` | `rugar`     |
+| [Susucoin](https://www.susukino.com/)          | `susu`        | `tutu`  | `ruru`      |
+| [Syscoin](https://syscoin.org/)                | `sys`         | `tsys`  | `scrt`      |
+| [Terra](https://terra.money/)                  | `terra`       |         |             |
+| [Tgrade](https://tgrade.finance/)              | `tgrade`      |         |             |
+| [Thorchain](https://thorchain.org/)            | `thor`        |         |             |
+| [Unit-e](https://dtr.org/unit-e/)              | `ue`          | `tue`   | `uert`      |
+| [Vertcoin](https://vertcoin.org/)              | `vtc`         | `tvtc`  |             |
+| [Viacoin](https://viacoin.org/)                | `via`         | `tvia`  |             |
+| [VIPSTARCOIN](https://www.vipstarcoin.jp/)     | `vips`        | `tvips` |             |
+| [YeeCo](https://www.yeeco.io/)                 | `yee`         | `tyee`  |             |
+| [Zen Protocol](https://zenprotocol.com/)       | `zen`         | `tzn`   |             |
+| [Zilliqa](https://zilliqa.com/)                | `zil`         | `tzil`  |             |
 
 ## Libraries
 

--- a/slip-0173.md
+++ b/slip-0173.md
@@ -21,55 +21,87 @@ The BIP repository does not want to deal with assigning the values for various c
 
 These are the registered human-readable parts for usage in Bech32 encoding of witness programs.
 
-| Coin                                           | Mainnet    | Testnet | Regtest     |
-| ---------------------------------------------- | ---------- | ------- | ----------- |
-| [Alaya](https://alaya.network/)                | `atp`      | `atx`   |             |
-| [BARE](https://bare.network)                   | `bare`     | `tbare` | `bart`      |
-| [Bellcoin](https://bellcoin.web4u.jp/)         | `bm`       | `bt`    | `br`        |
-| [Bitcoin](https://bitcoin.org/)                | `bc`       | `tb`    | `bcrt`      |
-| [Bitcoin Atom](https://bitcoinatom.io/)        | `bca`      | `tbca`  | `bcart`     |
-| [Bitcoin Gold](https://bitcoingold.org/)       | `btg`      | `tbtg`  |             |
-| [Bitcoin Platinum](https://btcplt.org/)        | `btp`      | `tbtp`  |             |
-| [Bitcoin Post-Quantum](https://bitcoinpq.org/) | `pq`       | `tq`    | `pqrt`      |
-| [Bitcoin Private](https://btcprivate.org/)     | `btcp`     | `tbtcp` | `regbtcp`   |
-| [Bitcore](https://bitcore.cc/)                 | `btx`      | `tbtx`  |             |
-| [BitZeny](https://bitzeny.tech/)               | `bz`       | `tz`    | `rz`        |
-| [Blacknet](https://blacknet.ninja/)            | `blacknet` |         | `rblacknet` |
-| [Cosmos Hub](https://cosmos.network/)          | `cosmos`   |         |             |
-| [CPUchain](https://cpuchain.org)               | `cpu`      | `tcpu`  | `rcpu`      |
-| [CranePay](https://cranepay.io/)               | `cp`       | `cpt`   | `cpr`       |
-| [Crypto.org Chain](https://crypto.org)         | `cro`      | `tcro`  |             |
-| [DigiByte](https://www.digibyte.io/)           | `dgb`      | `dgbt`  | `dgbrt`     |
-| [FujiCoin](http://www.fujicoin.org/)           | `fc`       | `tf`    | `fcrt`      |
-| [Groestlcoin](https://groestlcoin.org/)        | `grs`      | `tgrs`  | `grsrt`     |
-| [Handshake](https://handshake.org/)            | `hs`       | `ts`    | `rs`        |
-| [IoTeX](https://www.iotex.io/)                 | `io`       | `it`    |             |
-| [IOV](https://www.iov.one/)                    | `iov`      | `tiov`  |             |
-| [LatticeX](https://latticex.foundation/)       | `pla`      | `plt`   |             |
-| [Litecoin](https://litecoin.org/)              | `ltc`      | `tltc`  | `rltc`      |
-| [Monacoin](https://monacoin.org/)              | `mona`     | `tmona` | `rmona`     |
-| [Myriad](https://myriadcoin.org/)              | `my`       | `tm`    |             |
-| [Namecoin](https://www.namecoin.org/)          | `nc`       | `tn`    | `ncrt`      |
-| [Oasis Network](https://oasisprotocol.org/)    | `oasis`    | `oasis` |             |
-| [Omni](https://www.omnilayer.org)              | `o`        | `to`    | `ocrt`      |
-| [Osmosis](https://osmosis.zone)                | `osmo`     |         |             |
-| [Peercoin](https://www.peercoin.net)           | `xpc`      | `tpc`   |             |
-| [PKT](https://github.com/pkt-cash/pktd)        | `pkt`      | `tpk`   |             |
-| [PlatON](https://platon.network/)              | `lat`      | `lax`   |             |
-| [Quantum Resistant Ledger](https://theqrl.org) | `qrl`      | `tqrl`  | `qrlrt`     |
-| [Ravencoin](https://ravencoin.org/)            | `rc`       | `tr`    | `rcrt`      |
-| [Riecoin](https://riecoin.dev/)                | `ric`      | `tric`  | `rric`      |
-| [Sugarchain](https://sugarchain.org/)          | `sugar`    | `tugar` | `rugar`     |
-| [Susucoin](https://www.susukino.com/)          | `susu`     | `tutu`  | `ruru`      |
-| [Syscoin](https://syscoin.org/)                | `sys`      | `tsys`  | `scrt`      |
-| [Tgrade](https://tgrade.finance/)              | `tgrade`   |         |             |
-| [Unit-e](https://dtr.org/unit-e/)              | `ue`       | `tue`   | `uert`      |
-| [Vertcoin](https://vertcoin.org/)              | `vtc`      | `tvtc`  |             |
-| [Viacoin](https://viacoin.org/)                | `via`      | `tvia`  |             |
-| [VIPSTARCOIN](https://www.vipstarcoin.jp/)     | `vips`     | `tvips` |             |
-| [YeeCo](https://www.yeeco.io/)                 | `yee`      | `tyee`  |             |
-| [Zen Protocol](https://zenprotocol.com/)       | `zen`      | `tzn`   |             |
-| [Zilliqa](https://zilliqa.com/)                | `zil`      | `tzil`  |             |
+| Coin                                              | Mainnet       | Testnet | Regtest     |
+| ------------------------------------------------- | ------------- | ------- | ----------- |
+| [Agoric](https://agoric.com/)                     | `agoric`      |         |             |
+| [Akash Network](https://akash.network/)           | `akash`       |         |             |
+| [Alaya](https://alaya.network/)                   | `atp`         | `atx`   |             |
+| [Althea](https://althea.net/)                     | `althea`      |         |             |
+| [BARE](https://bare.network)                      | `bare`        | `tbare` | `bart`      |
+| [Band Protocol](https://bandprotocol.com/)        | `band`        |         |             |
+| [Bellcoin](https://bellcoin.web4u.jp/)            | `bm`          | `bt`    | `br`        |
+| [Binance Chain](https://docs.binance.org/)        | `bnb`         |         |             |
+| [Bitcoin](https://bitcoin.org/)                   | `bc`          | `tb`    | `bcrt`      |
+| [Bitcoin Atom](https://bitcoinatom.io/)           | `bca`         | `tbca`  | `bcart`     |
+| [Bitcoin Gold](https://bitcoingold.org/)          | `btg`         | `tbtg`  |             |
+| [Bitcoin Platinum](https://btcplt.org/)           | `btp`         | `tbtp`  |             |
+| [Bitcoin Post-Quantum](https://bitcoinpq.org/)    | `pq`          | `tq`    | `pqrt`      |
+| [Bitcoin Private](https://btcprivate.org/)        | `btcp`        | `tbtcp` | `regbtcp`   |
+| [Bitcore](https://bitcore.cc/)                    | `btx`         | `tbtx`  |             |
+| [Bitsong](https://bitsong.io/)                    | `bitsong`     |         |             |
+| [BitZeny](https://bitzeny.tech/)                  | `bz`          | `tz`    | `rz`        |
+| [Blacknet](https://blacknet.ninja/)               | `blacknet`    |         | `rblacknet` |
+| [CertiK Chain](https://www.certik.org/technology) | `certik`      |         |             |
+| [Cosmos Hub](https://cosmos.network/)             | `cosmos`      |         |             |
+| [Cosmos Hub](https://cosmos.network/)             | `cosmos`      |         |             |
+| [CPUchain](https://cpuchain.org)                  | `cpu`         | `tcpu`  | `rcpu`      |
+| [CranePay](https://cranepay.io/)                  | `cp`          | `cpt`   | `cpr`       |
+| [Crypto.org Chain](https://crypto.org)            | `cro`         | `tcro`  |             |
+| [Cyber](https://cybercongress.ai/)                | `cyber`       |         |             |
+| [Desmos](https://www.desmos.network/)             | `desmos`      |         |             |
+| [DigiByte](https://www.digibyte.io/)              | `dgb`         | `dgbt`  | `dgbrt`     |
+| [e-Money](https://www.e-money.com/)               | `emoney`      |         |             |
+| [fetch.ai](https://fetch.ai/)                     | `fetch`       |         |             |
+| [FujiCoin](http://www.fujicoin.org/)              | `fc`          | `tf`    | `fcrt`      |
+| [Groestlcoin](https://groestlcoin.org/)           | `grs`         | `tgrs`  | `grsrt`     |
+| [Handshake](https://handshake.org/)               | `hs`          | `ts`    | `rs`        |
+| [Injective](https://injectiveprotocol.com/)       | `inj`         |         |             |
+| [IoTeX](https://www.iotex.io/)                    | `io`          | `it`    |             |
+| [IRISnet](https://irisnet.org/)                   | `iris`        |         |             |
+| [Juno](https://junochain.com/)                    | `juno`        |         |             |
+| [Kava](https://www.kava.io/)                      | `kava`        |         |             |
+| [KiChain](https://foundation.ki/)                 | `ki`          |         |             |
+| [Kira Network](https://kira.network/)             | `kira`        |         |             |
+| [LatticeX](https://latticex.foundation/)          | `pla`         | `plt`   |             |
+| [Likecoin](https://like.co/)                      | `cosmos`      |         |             |
+| [Litecoin](https://litecoin.org/)                 | `ltc`         | `tltc`  | `rltc`      |
+| [Medibloc](https://medibloc.com/en/)              | `panacea`     |         |             |
+| [Microtick](https://microtick.com/)               | `micro`       |         |             |
+| [Monacoin](https://monacoin.org/)                 | `mona`        | `tmona` | `rmona`     |
+| [Myriad](https://myriadcoin.org/)                 | `my`          | `tm`    |             |
+| [Namecoin](https://www.namecoin.org/)             | `nc`          | `tn`    | `ncrt`      |
+| [Oasis Network](https://oasisprotocol.org/)       | `oasis`       | `oasis` |             |
+| [OKExChain](https://www.okex.com/okexchain)       | `ex`          |         |             |
+| [Omni](https://www.omnilayer.org)                 | `o`           | `to`    | `ocrt`      |
+| [Osmosis](https://osmosis.zone)                   | `osmo`        |         |             |
+| [Peercoin](https://www.peercoin.net)              | `xpc`         | `tpc`   |             |
+| [Persistence](https://persistence.one/)           | `persistence` |         |             |
+| [PKT](https://github.com/pkt-cash/pktd)           | `pkt`         | `tpk`   |             |
+| [PlatON](https://platon.network/)                 | `lat`         | `lax`   |             |
+| [Quantum Resistant Ledger](https://theqrl.org)    | `qrl`         | `tqrl`  | `qrlrt`     |
+| [Ravencoin](https://ravencoin.org/)               | `rc`          | `tr`    | `rcrt`      |
+| [Regen](https://www.regen.network/)               | `regen`       |         |             |
+| [Riecoin](https://riecoin.dev/)                   | `ric`         | `tric`  | `rric`      |
+| [Secret Network](https://scrt.network/)           | `secret`      |         |             |
+| [Sentinel](https://sentinel.co/)                  | `sent`        |         |             |
+| [Sifchain](https://sifchain.finance/)             | `sif`         |         |             |
+| [Stargaze](https://stargaze.zone/)                | `stars`       |         |             |
+| [Starname](https://www.starname.me/)              | `star`        |         |             |
+| [Straightedge](http://straighted.ge/)             | `str`         |         |             |
+| [Switcheo](https://www.switcheo.com/)             | `swth`        |         |             |
+| [Sugarchain](https://sugarchain.org/)             | `sugar`       | `tugar` | `rugar`     |
+| [Susucoin](https://www.susukino.com/)             | `susu`        | `tutu`  | `ruru`      |
+| [Syscoin](https://syscoin.org/)                   | `sys`         | `tsys`  | `scrt`      |
+| [Terra](https://terra.money/)                     | `terra`       |         |             |
+| [Tgrade](https://tgrade.finance/)                 | `tgrade`      |         |             |
+| [Thorchain](https://thorchain.org/)               | `thor`        |         |             |
+| [Unit-e](https://dtr.org/unit-e/)                 | `ue`          | `tue`   | `uert`      |
+| [Vertcoin](https://vertcoin.org/)                 | `vtc`         | `tvtc`  |             |
+| [Viacoin](https://viacoin.org/)                   | `via`         | `tvia`  |             |
+| [VIPSTARCOIN](https://www.vipstarcoin.jp/)        | `vips`        | `tvips` |             |
+| [YeeCo](https://www.yeeco.io/)                    | `yee`         | `tyee`  |             |
+| [Zen Protocol](https://zenprotocol.com/)          | `zen`         | `tzn`   |             |
+| [Zilliqa](https://zilliqa.com/)                   | `zil`         | `tzil`  |             |
 
 ## Libraries
 


### PR DESCRIPTION
Hi, I'm one of the core devs of the Cosmos ecosystem.  We actually use bech32 addresses as the default for all the chains in our ecosystem.  I just realized that only very few of the chains in Cosmos have registered themselves in the SLIP-173 repo, so I've gathered the HRP info of as many of them I could find, and added them.

The one deleted line is for "IOV", which is a stale entry because they have rebranded to Starname (which I included).  See: https://medium.com/iov-internet-of-values/iov-has-become-starname-a95e27165928