### PR TITLE
slip-0044: Flux rebranding

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1155,7 +1155,7 @@ Coin type | Path component (`coin_type'`) | Symbol | Coin
 16754 | 0x80004172 | ARDR   | [Ardor](https://www.jelurida.com)
 18000 | 0x80004650 | MTR    | [Meter](https://Meter.io)
 19165 | 0x80004add | SAFE   | [Safecoin](https://www.safecoin.org)
-19167 | 0x80004adf | ZEL    | [ZelCash](https://www.zel.cash)
+19167 | 0x80004adf | FLUX   | [Flux](https://runonflux.io)
 19169 | 0x80004ae1 | RITO   | [Ritocoin](https://www.ritocoin.org)
 20036 | 0x80004e44 | XND    | [ndau](https://ndau.io/)
 22504 | 0x800057e8 | PWR    | [PWRcoin](https://github.com/Plainkoin/PWRcoin)


### PR DESCRIPTION
Flux started life as "Zelcash", or simply "Zel". The project was rebranded to the Flux nomenclature March 27th, 2021.
https://runonflux.io
https://www.runonflux.io/roadmap