### PR TITLE
slip-0044: add Alephium coin

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1048,6 +1048,7 @@ Coin type | Path component (`coin_type'`) | Symbol | Coin
 1137  | 0x80000471 | $DAG   | [Constellation Labs](https://constellationnetwork.io/)
 1145  | 0x80000479 | CDY    | [Bitcoin Candy](http://www.bitcoincandy.one)
 1170  | 0x80000492 | HOO    | [Hoo Smart Chain](https://www.hoosmartchain.com/)
+1234  | 0x800004d2 | ALPH   | [Alephium](https://github.com/alephium/alephium/)
 1337  | 0x80000539 | DFC    | [Defcoin](http://defcoin-ng.org)
 1397  | 0x80000575 | HYC    | [Hycon](https://hycon.io)
 1410  | 0x80000582 | TENTSLP| TENT Simple Ledger Protocol


### PR DESCRIPTION
Hello,

we would like to add [Alephium](https://github.com/alephium/alephium/) into slip-0044.

Regarding the coin type number, our current dummy one defined [here](https://github.com/alephium/alephium/blob/33e1ec3ae3e2a0af1eb22cb928ed41f988a53d04/wallet/src/main/scala/org/alephium/wallet/Constants.scala#L25-L34) is not used so we thought we could go on with it :)

For the validity of our [BIP32 implementation](https://github.com/alephium/alephium/blob/33e1ec3ae3e2a0af1eb22cb928ed41f988a53d04/crypto/src/main/scala/org/alephium/crypto/wallet/BIP32.scala#L33), we are using the [bitcoin's test vectors](https://github.com/alephium/alephium/blob/33e1ec3ae3e2a0af1eb22cb928ed41f988a53d04/crypto/src/test/scala/org/alephium/crypto/wallet/BIP32Spec.scala#L49)

Cheers
