### PR TITLE
Remove evmos testnet prefix

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -50,7 +50,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | [Desmos](https://www.desmos.network/)          | `desmos`      |         |             |
 | [DigiByte](https://www.digibyte.io/)           | `dgb`         | `dgbt`  | `dgbrt`     |
 | [e-Money](https://www.e-money.com/)            | `emoney`      |         |             |
-| [Evmos](https://evmos.org/)                    | `evmos`       | `evmost`|             |
+| [Evmos](https://evmos.org/)                    | `evmos`       |         |             |
 | [fetch.ai](https://fetch.ai/)                  | `fetch`       |         |             |
 | [FujiCoin](http://www.fujicoin.org/)           | `fc`          | `tf`    | `fcrt`      |
 | [Groestlcoin](https://groestlcoin.org/)        | `grs`         | `tgrs`  | `grsrt`     |


### PR DESCRIPTION
We realized that other cosmos chains ommit the testnet prefix and that this works for us too.
