### PR TITLE
Update slip-0044.md

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -652,7 +652,7 @@ Coin type | Path component (`coin_type'`) | Symbol | Coin
 621   | 0x8000026d |        |
 622   | 0x8000026e |        |
 623   | 0x8000026f |        |
-624   | 0x80000270 |        |
+624   | 0x80000270 | NOBL   | [Nobility](https://github.com/nobilitysociety/)
 625   | 0x80000271 | EAST   | [Eastcoin](http://easthub.io/)
 626   | 0x80000272 |        |
 627   | 0x80000273 |        |


### PR DESCRIPTION
Added Algorand-Based cryptocurrency "NOBL", "Nobility" to line 655, number 624, BIP-0044 = "0x80000270". Previously vacant.