### PR TITLE
Remove trademark violation

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1141,7 +1141,6 @@ Coin type | Path component (`coin_type'`) | Symbol | Coin
 8217  | 0x80002019 | KLAY   | [KLAY](https://www.klaytn.com)
 8339  | 0x80002093 | BTQ    | [BitcoinQuark](https://www.bitcoinquark.org)
 8444  | 0x800020fc | XCH    | [Chia](https://www.chia.net)
-8520  | 0x80002148 | XCR    | [ChiaRose](https://chiarose.com/)
 8888  | 0x800022b8 | SBTC   | [Super Bitcoin](https://www.superbtc.org)
 8964  | 0x80002304 | NULS   | [NULS](https://nuls.io)
 8999  | 0x80002327 | BTP    | [Bitcoin Pay](http://www.btceasypay.com)


### PR DESCRIPTION
Chia Network owns the registered US Trademark 6,428,600 and the registered EU Trademark 017930981 on the word "chia" as applied to cryptocurrencies as well as many other jurisdictions around the world. This developer (@snight) is free to name it something like greenrose or coinrose, but the current use is a violation of our Marks.

We have already taken over the chiarose.com domain name in ICANN arbitration.