### PR TITLE
Add Creamcoin (CRM) coin type

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1217,6 +1217,7 @@ Coin type | Path component (`coin_type'`) | Symbol | Coin
 5264462 | 0x8050544e | PTN    | [PalletOne](https://pallet.one)
 5718350 | 0x8057414e | WAN    | [Wanchain](https://wanchain.org)
 5741564 | 0x80579bfc | WAVES  | [Waves](https://wavesplatform.com)
+6517357 | 0x8063726d | CRM    | [Creamcoin](https://explorer.creamcoin.com/)
 7562605 | 0x8073656d | SEM    | [Semux](https://semux.org)
 7567736 | 0x80737978 | ION    | [ION](https://ionomy.com)
 7777777 | 0x8076adf1 | FCT    | [FirmaChain](https://www.firmachain.org)


### PR DESCRIPTION
The value was chosen by `Buffer.from('crm').toString('hex')`.

Disclaimer: I do not represent Creamcoin but I need a standard coin type for it's integration in our codebase.