### PR TITLE
Clarification about P-256 domain parameters 

### DIFF
--- a/slip-0010.md
+++ b/slip-0010.md
@@ -40,12 +40,15 @@ for different elliptic curves with different orders.
 We adapt the master key generation from BIP-0032.  To use different
 private keys for different curves we use different keys for the HMAC
 hash that generates the master key.  For the NIST P-256 curve the only
-other difference is the different group order.  In the algorithm below
-we denote the group order of the elliptic curve by n. For the ed25519
-curve the private keys are no longer multipliers for the group
-generator; instead the hash of the private key is the multiplier.  For
-this reason, our scheme for ed25519 does not support public key
-derivation and uses the produced hashes directly as private keys.
+other difference is the curve domain parameters.  In the algorithm below
+we denote the group order of the elliptic curve by n. point(k) is the 
+scalar multiplication of the curve generator by the scalar k. 
+The operation (+) of two elements on the curve is the group point 
+addition.    For the ed25519 curve the private keys are no longer 
+multipliers for the group generator; instead the hash of the private 
+key is the multiplier.  For this reason, our scheme for ed25519 does
+not support public key derivation and uses the produced hashes directly
+as private keys.
 
 To avoid invalid master keys, the algorithm is retried with the
 intermediate hash as new seed if the key is invalid.
@@ -74,7 +77,7 @@ For ed25519, the last step always succeeds since every 256-bit number
 ### Child key derivation (CKD) functions
 
 Private and public key derivation for NIST P-256 is identical to the
-generation for secp256k1 but uses the order of that curve as modulo.
+generation for secp256k1 but uses the domain parameters of that curve.
 We change BIP-32 to not fail if the resulting key is not valid but
 retry hashing until a valid key is found.  For ed25519 only hardened
 key generation from Private parent key to private child key is supported.


### PR DESCRIPTION
The document mentions that extending BIP32 algorithms from secp256k1 to NIST P-256 only requires substituting the curve order (n) of secp256k1 by the order of P-256. 

While this is correct in the case of Private parent key → hardened private child key, more curve domain parameters need to be substituted for :
 - Private parent key → non-hardened private child key  (scalar point multiplication is needed)
 - Public parent key → non-hardened public child key (scalar point multiplication and point addition are needed)
In these 2 cases, it is required to also substitute the prime field (F_p), the base point (G), and the Weierstrass equation parameter (a). 

The proposition updates the document to mention the domain parameter change and highlight the primitives that need be updated to the new curve. This should avoid possible confusion in the implementations.