### PR TITLE
Update slip-0173.md

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -43,6 +43,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | [BitZeny](https://bitzeny.tech/)                | `bz`          | `tz`    | `rz`        |
 | [Blacknet](https://blacknet.ninja/)             | `blacknet`    |         | `rblacknet` |
 | [bostrom](https://cyb.ai/)                      | `bostrom`     |         |             |
+| [Carbon](https://carbon.network/)               | `swth`        |         |             |
 | [CertiK Chain](https://www.certik.org/about)    | `certik`      |         |             |
 | [cheqd](https://www.cheqd.io)                   | `cheqd`       |         |             |
 | [Cosmos Hub](https://cosmos.network/)           | `cosmos`      |         |             |
@@ -96,7 +97,6 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | [Stargaze](https://stargaze.zone/)              | `stars`       |         |             |
 | [Starname](https://www.starname.me/)            | `star`        |         |             |
 | [Straightedge](http://straighted.ge/)           | `str`         |         |             |
-| [Switcheo](https://www.switcheo.com/)           | `swth`        |         |             |
 | [Sugarchain](https://sugarchain.org/)           | `sugar`       | `tugar` | `rugar`     |
 | [Susucoin](https://www.susukino.com/)           | `susu`        | `tutu`  | `ruru`      |
 | [Syscoin](https://syscoin.org/)                 | `sys`         | `tsys`  | `scrt`      |


### PR DESCRIPTION
Switcheo TradeHub has been renamed to Carbon. See: https://blog.switcheo.com/meet-carbon-the-core-of-decentralized-financial-markets/

This PR updates the coin name and url. There is no change in prefix for backward compatibility.