### PR TITLE
Add "Non-Segwit-compatible uses of Bech32 / Bech32m" section with Zcash HRPs

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -113,6 +113,24 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | [Zen Protocol](https://zenprotocol.com/)        | `zen`         | `tzn`   |             |
 | [Zilliqa](https://zilliqa.com/)                 | `zil`         | `tzil`  |             |
 
+## Non-Segwit-compatible uses of Bech32 / Bech32m
+
+The following human-readable parts are registered for formats using Bech32 or Bech32m
+that are not compatible with Segwit. Entries annotated with "(m)" use Bech32m [BIP-0350];
+other entries use Bech32.
+
+| Coin                                            | Mainnet                    | Testnet                    | Regtest                       |
+| ----------------------------------------------  | -------------------------- | -------------------------- | ----------------------------- |
+| [Zcash](https://z.cash)                         | `zs`                       | `ztestsapling`             | `zregtestsapling`             |
+|                                                 | `zivks`                    | `zivktestsapling`          | `zivkregtestsapling`          |
+|                                                 | `zxviews`                  | `zxviewtestsapling`        | `zxviewregtestsapling`        |
+|                                                 | `zxsprout`                 | `zxtestsprout`             | `zxregtestsprout`             |
+|                                                 | `secret-spending-key-main` | `secret-spending-key-test` | `secret-spending-key-regtest` |
+|                                                 | `secret-extended-key-main` | `secret-extended-key-test` | `secret-extended-key-regtest` |
+|                                                 | `u` (m)                    | `utest` (m)                | `uregtest` (m)                |
+|                                                 | `uivk` (m)                 | `uivktest` (m)             | `uivkregtest` (m)             |
+|                                                 | `uview` (m)                | `uviewtest` (m)            | `uviewregtest` (m)            |
+
 ## Libraries
 
 * [Reference Implementations](https://github.com/sipa/bech32/tree/master/ref)
@@ -120,3 +138,4 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 ## References
 
 * [BIP-0173: Base32 address format for native v0-16 witness outputs](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki)
+* [BIP-0350: Bech32m format for v1+ witness addresses](https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki)


### PR DESCRIPTION
closes zcash/zips#583

Signed-off-by: Daira Hopwood <daira@jacaranda.org>