### PR TITLE
slip-0173: add coin

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -74,6 +74,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | [Konstellation](https://konstellation.tech/)    | `darc`        |         |             |
 | [Kylacoin](https://kylacoin.v6.army/)           | `kc`          | `tkc`   | `kcrt`      |
 | [LatticeX](https://latticex.foundation/)        | `pla`         | `plt`   |             |
+| [LikeCoin](https://like.co/)                    | `like`        |         |             |
 | [Litecoin](https://litecoin.org/)               | `ltc`         | `tltc`  | `rltc`      |
 | [Medibloc](https://medibloc.com/en/)            | `panacea`     |         |             |
 | [Microtick](https://microtick.com/)             | `micro`       |         |             |


### PR DESCRIPTION
registering for our chain prefix upgrade to `like`