### PR TITLE
SLIP44: Added Astar Network coin

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -838,7 +838,7 @@ Coin type | Path component (`coin_type'`) | Symbol | Coin
 807   | 0x80000327 |        |
 808   | 0x80000328 | QVT    | [Qvolta](https://qvolta.com)
 809   | 0x80000329 |        |
-810   | 0x8000032a |        |
+810   | 0x8000032a | ASTR   | [Astar Network](https://astar.network)
 811   | 0x8000032b | DVPN   | [Sentinel](https://sentinel.co)
 812   | 0x8000032c |        |
 813   | 0x8000032d |        |


### PR DESCRIPTION
**Description**

Astar is the Polkadot-native parachain supporting Ethereum, WebAssembly, dApp Staking, and Layer2 solutions.