### PR TITLE
Fix velas derivation path

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -602,7 +602,7 @@ Coin type | Path component (`coin_type'`) | Symbol | Coin
 571   | 0x8000023b | CCXX   | [Counos X](https://www.counos.io/CounosX)
 572   | 0x8000023c | SLS    | [Saluscoin](https://saluscoin.info)
 573   | 0x8000023d | SRM    | [Serum](https://projectserum.com)
-574   | 0x8000023e | VLX    | [Velas](https://velas.com)
+574   | 0x8000023e | ---    | reserved
 575   | 0x8000023f | VIVT   | [VIDT Datalink](https://about.v-id.org)
 576   | 0x80000240 | BPS    | [BitcoinPoS](https://bitcoinpos.net)
 577   | 0x80000241 | NKN    | [NKN](https://www.nkn.org)
@@ -1224,6 +1224,7 @@ Coin type | Path component (`coin_type'`) | Symbol | Coin
 5249353 | 0x80501949 | BCO    | [BitcoinOre](http://bitcoinore.org)
 5249354 | 0x8050194a | BHD    | [BitcoinHD](https://btchd.org)
 5264462 | 0x8050544e | PTN    | [PalletOne](https://pallet.one)
+5655640 | 0x80564c58 | VLX    | [Velas](https://velas.com)
 5718350 | 0x8057414e | WAN    | [Wanchain](https://wanchain.org)
 5741564 | 0x80579bfc | WAVES  | [Waves](https://wavesplatform.com)
 5741565 | 0x80579bfd | WEST   | [Waves Enterprise](https://wavesenterprise.com)


### PR DESCRIPTION
We found that in this commit https://github.com/satoshilabs/slips/commit/1140ce26a621a23cd99460497e08aa4aab6e9f8c
Someone add VLX to the list.

In velas we use different constant https://github.com/velas/web3t/blob/master/providers/solana.js#L219
(Note: module solana because our chain is based on solana fork)


