### PR TITLE
Add CCD coin.

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -947,7 +947,7 @@ Coin type | Path component (`coin_type'`) | Symbol | Coin
 916   | 0x80000394 | META   | [Metadium](https://www.metadium.com)
 917   | 0x80000395 | FRA    | [Findora](https://www.findora.org)
 918   | 0x80000396 |        |
-919   | 0x80000397 |        |
+919   | 0x80000397 | CCD    | [Concordium](https://www.concordium.com/)
 920   | 0x80000398 |        |
 921   | 0x80000399 |        |
 922   | 0x8000039a |        |


### PR DESCRIPTION
Adding coin type 919 for Concordium's CCD coin.