### PR TITLE
feat(slip-0044): add KCS token and KCC network

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -669,8 +669,8 @@ Coin type | Path component (`coin_type'`) | Symbol | Coin
 638   | 0x8000027e |        |
 639   | 0x8000027f | BTSG   |  [BitSong](https://bitsong.io)
 640   | 0x80000280 | LFC    |  [Leofcoin](https://leofcoin.org)
-641   | 0x80000281 |        |
-642   | 0x80000282 |        |
+641   | 0x80000281 | KCS    |  [KuCoin Shares](https://kcs.foundation)
+642   | 0x80000282 | KCC    |  [KuCoin Community Chain](https://kcc.io)
 643   | 0x80000283 | AZERO  |  [Aleph Zero](https://alephzero.org)
 644   | 0x80000284 |        |
 645   | 0x80000285 |        |


### PR DESCRIPTION
The KCS (KuCoin Shares) token, besides being an ERC20 smart contract token on the Ethereum chain currently, is also the native token on KCC (KuCoin Community Chain).