### PR TITLE
add BIP44 coin type for WAMP

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -683,7 +683,7 @@ Coin type | Path component (`coin_type'`) | Symbol | Coin
 652   | 0x8000028c |        |
 653   | 0x8000028d |        |
 654   | 0x8000028e |        |
-655   | 0x8000028f |        |
+655   | 0x8000028f | WMP    | [WAMP](https://wamp-proto.org/)
 656   | 0x80000290 |        |
 657   | 0x80000291 |        |
 658   | 0x80000292 |        |
@@ -1015,7 +1015,7 @@ Coin type | Path component (`coin_type'`) | Symbol | Coin
 984   | 0x800003d8 |        |
 985   | 0x800003d9 | AU     | [Autonomy](https://bitmark.com/autonomy)
 986   | 0x800003da |        |
-987   | 0x800003db | VCG    | [VipCoin.Gold](https://vipcoin.gold)  
+987   | 0x800003db | VCG    | [VipCoin.Gold](https://vipcoin.gold)
 988   | 0x800003dc | XAZAB  | [Xazab core](https://github.com/xazab)
 989   | 0x800003dd | AIOZ   | [AIOZ](https://aioz.network)
 990   | 0x800003de |        |


### PR DESCRIPTION
Add BIP44 coin type for WAMP:

* https://wamp-proto.org/
* https://github.com/wamp-proto/wamp-proto/
* https://app.ens.domains/name/wmp.eth/details