### PR TITLE
slip-0044: remove coin

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -648,7 +648,7 @@ Coin type | Path component (`coin_type'`) | Symbol | Coin
 617   | 0x80000269 | XOR    | [Sora](https://sora.org/soratokens)
 618   | 0x8000026a | SSP    | [SmartShare](http://www.smartshare.vip)
 619   | 0x8000026b | DEI    | [DeimosX](https://deimosx.org)
-620   | 0x8000026c | AXL    | [Axelar](https://axelar.network)
+620   | 0x8000026c |        |
 621   | 0x8000026d | ZERO   | [Singularity](https://www.singularity.gold)
 622   | 0x8000026e | ALPHA  | [AlphaDAO](https://www.alphadao.money)
 623   | 0x8000026f | BDCASH | [BDCash Protocol](https://bdcashprotocol.com)


### PR DESCRIPTION
Axelar decided to use the Cosmos ecosystem default of `118` for `AXL`. Reference in the [cosmos chain registry](https://github.com/cosmos/chain-registry/blob/master/axelar/chain.json#L17).