### PR TITLE
Add Slashtags to SLIP-0044

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -729,7 +729,7 @@ Coin type | Path component (`coin_type'`) | Symbol | Coin
 698   | 0x800002ba | VEIL   | [Veil](https://www.veil-project.com)
 699   | 0x800002bb | GIO    | [Gio](https://github.com/qGio)
 700   | 0x800002bc | XDAI   | [xDai](https://blockscout.com/poa/dai)
-701   | 0x800002bd |        |
+701   | 0x800002bd | COM    | [Commercio.network](https://commercio.network)
 702   | 0x800002be |        |
 703   | 0x800002bf |        |
 704   | 0x800002c0 |        |


### PR DESCRIPTION
[Slashtags](https://github.com/synonymdev/slashtags) are keyPairs acting as decentralized identifiers and addresses for further metadata over data structures optimized for p2p sharing.

Slashtags' keyPairs can be derived from a `primaryKey` and a `name`. This `primaryKey` can and should be derived from a Bitcoin seed.

The derivation scheme is described [here](https://github.com/synonymdev/slashtags/blob/master/specs/slashtags-key-derivation.md#from-seed-to-primarykey). 