### PR TITLE
Make Markdown linguist-detectable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.md linguist-detectable


### PR DESCRIPTION
Before this change, repository gets detected as:

Python 95.3%
Shell 4.7%

After this change, repository gets detected as:

Markdown 95.4%
Python 4.4%
Shell 0.2%

This change was added for a cosmetic effect on GitHub, and the line
this change adds can go away at any moment.

---

See also: pull request 930 in lightning/bolts.
See also: pull request 1203 in bitcoin/bips.
