### PR TITLE
Update slip-0044.md

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -234,7 +234,7 @@ Coin type | Path component (`coin_type'`) | Symbol | Coin
 203   | 0x800000cb | CNMC   | [Cryptonodes](https://www.cryptonodes.ch)
 204   | 0x800000cc | BCN    | [Bytecoin](http://bytecoin.org)
 205   | 0x800000cd | RIN    | [Ringo](http://dkwzjw.github.io/ringo)
-206   | 0x800000ce | ATP    | [PlatON](https://www.platon.network)
+206   | 0x800000ce | ATP    | [Alaya](https://www.alaya.network)
 207   | 0x800000cf | EVT    | [everiToken](https://everiToken.io)
 208   | 0x800000d0 | ATN    | [ATN](https://atn.io)
 209   | 0x800000d1 | BIS    | [Bismuth](http://www.bismuth.cz)


### PR DESCRIPTION
The description of ATP Coin in slip-0044 is not consistent with slip-0173, modify the Coin field content to Alaya, thanks.