### PR TITLE
Update Blockstack to Stacks

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1143,7 +1143,7 @@ Coin type | Path component (`coin_type'`) | Symbol | Coin
 5353  | 0x800014e9 | HNS    | [Handshake](https://handshake.org)
 5404  | 0x8000151c | ISK    | [ISKRA](https://iskra.world)
 5555  | 0x800015b3 | FUND   | [Unification](https://unification.com)
-5757  | 0x8000167d | STX    | [Blockstack](https://github.com/blockstack/blockstack-core)
+5757  | 0x8000167d | STX    | [Stacks](https://github.com/stacks-network/stacks-blockchain)
 5895  | 0x80001707 | VOW    | [VowChain VOW](https://vowchain.net)
 5920  | 0x80001720 | SLU    | [SILUBIUM](https://github.com/SilubiumProject/slucore)
 6060  | 0x800017ac | GO     | [GoChain GO](https://gochain.io)


### PR DESCRIPTION
Hello! This is a simple change as `Blockstack` was rebranded to `Stacks` in October 2020, and the repository has since moved as well since the 2.0 mainnet launched in January 2021.

Linked for reference are the [original blog announcement of the rebrand](https://blog.blockstack.org/stacks/) and the [related FAQ in a forum post](https://forum.stacks.org/t/faq-stacks-rebrand/11274).

The current GitHub link `https://github.com/blockstack/blockstack-core` redirects to `https://github.com/stacks-network/stacks-blockchain` so I updated the link to the new location as well.