### PR TITLE
Include Koinos in the list of tokens

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -687,7 +687,7 @@ Coin type | Path component (`coin_type'`) | Symbol | Coin
 656   | 0x80000290 |        |
 657   | 0x80000291 |        |
 658   | 0x80000292 |        |
-659   | 0x80000293 |        |
+659   | 0x80000293 | KOIN   | [Koinos](https://koinos.io/)
 660   | 0x80000294 | PIRATE | [PirateCash](https://piratecash.net)
 661   | 0x80000295 |        |
 662   | 0x80000296 |        |


### PR DESCRIPTION
Koinos will use the identifier **659**. This value was selected by taking the word "koinos", converting it to ascii [107 111 105 110 111 115], and adding their values.
References:
- https://peakd.com/koinos/@jga/kondor04
- https://koinos.io