### PR TITLE
Remove Sentinel registration of 811

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -839,7 +839,7 @@ Coin type | Path component (`coin_type'`) | Symbol | Coin
 808   | 0x80000328 | QVT    | [Qvolta](https://qvolta.com)
 809   | 0x80000329 | SDN    | [Shiden Network](https://shiden.astar.network/)
 810   | 0x8000032a | ASTR   | [Astar Network](https://astar.network)
-811   | 0x8000032b | DVPN   | [Sentinel](https://sentinel.co)
+811   | 0x8000032b |        | 
 812   | 0x8000032c |        |
 813   | 0x8000032d | MEER   | [Qitmeer](https://github.com/Qitmeer)
 814   | 0x8000032e |        |


### PR DESCRIPTION
Remove Sentinel's registration of CoinType 811. They use 118.