### PR TITLE
Remove Metaprotocol

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -97,7 +97,6 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | [LumenX](https://lumenex.io/)                   | `lumen`       |         |             |
 | [Medibloc](https://medibloc.com/en/)            | `panacea`     |         |             |
 | [MEME](https://meme.sx/)                        | `meme`        |         |             |
-| [Metaprotocol](https://metaprotocol.ai/)        | `lumen`       |         |             |
 | [Microtick](https://microtick.com/)             | `micro`       |         |             |
 | [Monacoin](https://monacoin.org/)               | `mona`        | `tmona` | `rmona`     |
 | [Moneta Coin](https://moneta.today/monetacoin)  | `moneta`      |         |             |


### PR DESCRIPTION
was recently replaced by the 'LumixX' entry (same bech32 prefix)