### PR TITLE
Add Nomic to SLIP-0173

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -104,6 +104,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | [Myriad](https://myriadcoin.org/)               | `my`          | `tm`    |             |
 | [Mythos](https://provable.dev/)                 | `mythos`      |         |             |
 | [Namecoin](https://www.namecoin.org/)           | `nc`          | `tn`    | `ncrt`      |
+| [Nomic](https://nomic.io/)                      | `nomic`       |         |             |
 | [Oasis Network](https://oasisprotocol.org/)     | `oasis`       | `oasis` |             |
 | [Octa Coin](https://octa-coin.com/)             | `octa`        |         |             |
 | [Odin Protocol](https://odinprotocol.io/)       | `odin`        |         |             |


### PR DESCRIPTION
This PR adds @nomic-io (https://nomic.io) to SLIP-0173. Thanks!