### PR TITLE
Bulk Chain Name Changes

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -25,7 +25,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | ----------------------------------------------  | ------------- | ------- | ----------- |
 | [Agoric](https://agoric.com/)                   | `agoric`      |         |             |
 | [AIOZ Network](https://aioz.network)            | `aioz`        |         |             |
-| [Akash Network](https://akash.network/)         | `akash`       |         |             |
+| [Akash](https://akash.network/)                 | `akash`       |         |             |
 | [Alaya](https://alaya.network/)                 | `atp`         | `atx`   |             |
 | [Althea](https://althea.net/)                   | `althea`      |         |             |
 | [Arkhadian](https://wallet.arkhadian.com/)      | `arkh`        |         |             |
@@ -42,13 +42,12 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | [Bitcoin Post-Quantum](https://bitcoinpq.org/)  | `pq`          | `tq`    | `pqrt`      |
 | [Bitcoin Private](https://btcprivate.org/)      | `btcp`        | `tbtcp` | `regbtcp`   |
 | [Bitcore](https://bitcore.cc/)                  | `btx`         | `tbtx`  |             |
-| [Bitsong](https://bitsong.io/)                  | `bitsong`     |         |             |
+| [BitSong](https://bitsong.io/)                  | `bitsong`     |         |             |
 | [BitZeny](https://bitzeny.tech/)                | `bz`          | `tz`    | `rz`        |
 | [Blacknet](https://blacknet.ninja/)             | `blacknet`    |         | `rblacknet` |
 | [bostrom](https://cyb.ai/)                      | `bostrom`     |         |             |
 | [Carbon](https://carbon.network/)               | `swth`        |         |             |
 | [Cerberus](https://cerberus.zone/)              | `cerberus`    |         |             |
-| [CertiK Chain](https://www.certik.org/about)    | `certik`      |         |             |
 | [cheqd](https://www.cheqd.io)                   | `cheqd`       |         |             |
 | [Chihuahua](https://chihuahua.wtf/)             | `chihuahua`   |         |             |
 | [Chronic Chain](https://chronicchain.io/)       | `chronic`     |         |             |
@@ -63,17 +62,17 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | [Cyber](https://cybercongress.ai/)              | `cyber`       |         |             |
 | [Decentr](https://decentr.net/)                 | `decentr`     |         |             |
 | [Desmos](https://www.desmos.network/)           | `desmos`      |         |             |
-| [Dig](https://digchain.org)                     | `dig`         |.        |.            |
+| [Dig Chain](https://digchain.org)               | `dig`         |.        |.            |
 | [DigiByte](https://www.digibyte.io/)            | `dgb`         | `dgbt`  | `dgbrt`     |
 | [Echelon](https://ech.network)                  | `echelon`     |         |             |
 | [e-Money](https://www.e-money.com/)             | `emoney`      |         |             |
 | [Evmos](https://evmos.org/)                     | `evmos`       |         |             |
-| [fetch.ai](https://fetch.ai/)                   | `fetch`       |         |             |
+| [Fetch.ai](https://fetch.ai/)                   | `fetch`       |         |             |
 | [FujiCoin](http://www.fujicoin.org/)            | `fc`          | `tf`    | `fcrt`      |
 | [Galaxy](https://galaxychain.zone/)             | `galaxy`      |         |             |
 | [GenesisL1](https://genesisl1.com)              | `genesis`     |         |             |
 | [Gitopia](https://gitopia.com/)                 | `gitopia`     |         |             |
-| [Gravity-Bridge](https://www.gravitybridge.net/)| `gravity`     |         |             |
+| [Gravity Bridge](https://www.gravitybridge.net/)| `gravity`     |         |             |
 | [Groestlcoin](https://groestlcoin.org/)         | `grs`         | `tgrs`  | `grsrt`     |
 | [Handshake](https://handshake.org/)             | `hs`          | `ts`    | `rs`        |
 | [Hash](https://provenance.io/)                  | `pb`          | `tp`    |             |
@@ -83,10 +82,10 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | [IOTA](https://iota.org)                        | `iota`        | `atoi`  |             |
 | [IoTeX](https://www.iotex.io/)                  | `io`          | `it`    |             |
 | [IRISnet](https://irisnet.org/)                 | `iris`        |         |             |
-| [IXO](https://ixo.world/)                       | `ixo`         |         |             |
+| [Impact Hub](https://ixo.world/)                | `ixo`         |         |             |
 | [Juno](https://junochain.com/)                  | `juno`        |         |             |
 | [Kava](https://www.kava.io/)                    | `kava`        |         |             |
-| [KiChain](https://foundation.ki/)               | `ki`          |         |             |
+| [Ki](https://foundation.ki/)                    | `ki`          |         |             |
 | [Kira Network](https://kira.network/)           | `kira`        |         |             |
 | [Konstellation](https://konstellation.tech/)    | `darc`        |         |             |
 | [Kylacoin](https://kylacoin.eu.org/)            | `kc`          | `tkc`   | `kcrt`      |
@@ -106,7 +105,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | [Namecoin](https://www.namecoin.org/)           | `nc`          | `tn`    | `ncrt`      |
 | [Nomic](https://nomic.io/)                      | `nomic`       |         |             |
 | [Oasis Network](https://oasisprotocol.org/)     | `oasis`       | `oasis` |             |
-| [Octa Coin](https://octa-coin.com/)             | `octa`        |         |             |
+| [Octa](https://octa-coin.com/)                  | `octa`        |         |             |
 | [Odin Protocol](https://odinprotocol.io/)       | `odin`        |         |             |
 | [OKExChain](https://www.okex.com/okexchain)     | `ex`          |         |             |
 | [Omni](https://www.omnilayer.org)               | `o`           | `to`    | `ocrt`      |
@@ -125,6 +124,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | [Rizon](https://rizon.world/)                   | `rizon`       |         |             |
 | [Secret Network](https://scrt.network/)         | `secret`      |         |             |
 | [Sentinel](https://sentinel.co/)                | `sent`        |         |             |
+| [Shentu](https://www.shentu.technology/)        | `certik`      |         |             |
 | [Shimmer](https://shimmer.network)              | `smr`         | `rms`   |             |
 | [Sifchain](https://sifchain.finance/)           | `sif`         |         |             |
 | [Sommelier](https://sommelier.finance)          | `somm`        |         |             |
@@ -134,7 +134,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | [Sugarchain](https://sugarchain.org/)           | `sugar`       | `tugar` | `rugar`     |
 | [Susucoin](https://www.susukino.com/)           | `susu`        | `tutu`  | `ruru`      |
 | [Syscoin](https://syscoin.org/)                 | `sys`         | `tsys`  | `scrt`      |
-| [Terra](https://terra.money/)                   | `terra`       |         |             |
+| [Terra Classic](https://terra.money/)           | `terra`       |         |             |
 | [Tgrade](https://tgrade.finance/)               | `tgrade`      |         |             |
 | [Thorchain](https://thorchain.org/)             | `thor`        |         |             |
 | [Ulas](https://ulas.network/)                   | `ulas`        |         |             |


### PR DESCRIPTION
-Akash Network -> Akash
-Bitsong -> BitSong
-Dig -> Dig Chain
-fetch.ai -> Fetch.ai
-Gravity-Bridge -> Gravity Bridge
-IXO -> Impact Hub
-KiChain -> Ki
-Octa Coin -> Octa
-Certik Chain -> Shentu (Rebranded CertiK to Shentu)
https://www.shentu.technology/
-Terra -> Terra Classic (Renamed after collapse)

This better matches the chain's "Pretty Name" is the Cosmos Chain Registry https://github.com/cosmos/chain-registry