### PR TITLE
bech32_prefix iris -> iaa

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -87,7 +87,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | [Injective](https://injectiveprotocol.com/)     | `inj`         |         |             |
 | [IOTA](https://iota.org)                        | `iota`        | `atoi`  |             |
 | [IoTeX](https://www.iotex.io/)                  | `io`          | `it`    |             |
-| [IRISnet](https://irisnet.org/)                 | `iris`        |         |             |
+| [IRISnet](https://irisnet.org/)                 | `iaa`         |         |             |
 | [Impact Hub](https://ixo.world/)                | `ixo`         |         |             |
 | [Juno](https://junochain.com/)                  | `juno`        |         |             |
 | [Kava](https://www.kava.io/)                    | `kava`        |         |             |


### PR DESCRIPTION
recently 'corrected' this to iris because there was a discrepancy, and iris made more sense to me, but it's actually indeed iaa, as I see by IRISfoundation, as well as I see in Keplr