### PR TITLE
Update SLIP44 to add RAILGUN

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1088,7 +1088,7 @@ Coin type | Path component (`coin_type'`) | Symbol | Coin
 1926  | 0x80000786 | CITY   | [City Coin](https://city-chain.org)
 1955  | 0x800007a3 | XX     | [xx coin](https://xx.network)
 1977  | 0x800007b9 | XMX    | [Xuma](http://www.xumacoin.org)
-1984  | 0x800007c0 | TRTL   | [TurtleCoin](https://turtlecoin.lol)
+1984  | 0x800007c0 | RAIL   | [RAILGUN](https://railgun.org)
 1987  | 0x800007c3 | EGEM   | [EtherGem](https://egem.io)
 1989  | 0x800007c5 | HODL   | [HOdlcoin](https://hodlcoin.com)
 1990  | 0x800007c6 | PHL    | [Placeholders](https://placeh.io)


### PR DESCRIPTION
This PR changes the 1984 coin type from TurtleCoin to RAILGUN.

## Adding RAILGUN
Website: [railgun.org](https://railgun.org)

Wallet implementing BIP-44: [Railway](https://railway.xyz)

SDK code where BIP44 value is used: [Lepton](https://github.com/Railgun-Community/lepton/blob/5be07bcf718d6b54320295358907742f8e897c50/src/keyderivation/wallet-node.ts#L18)

## TurtleCoin Depreciation

The [TurtleCoin website](https://turtlecoin.lol) points to the releases page of an archived repository. The description of the repository is as follows:

> The TurtleCoin network is in the process of shutting down as of November 2021. Please make your way to the door.

and releases page states:

> Please also note that this final release marks the End of Life for this iteration of TurtleCoin.
>
> Funds should be migrated within the coming year over to wTRTL, the next iteration of our adventure as a community.

As wTRTL is a token on the Fantom chain we can consider the standalone network which uses this derivation path depreciated.
