### PR TITLE
Adding Pactus CoinType for BIP44

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1199,6 +1199,7 @@ Coin type | Path component (`coin_type'`) | Symbol | Coin
 19169 | 0x80004ae1 | RITO   | [Ritocoin](https://www.ritocoin.org)
 20036 | 0x80004e44 | XND    | [ndau](https://ndau.io)
 21004 | 0x8000520c | C4EI   | [c4ei](https://c4ei.net)
+21888 | 0x80005580 | PCT    | [Pactus](https://pactus.org)
 22504 | 0x800057e8 | PWR    | [PWRcoin](https://github.com/Plainkoin/PWRcoin)
 25252 | 0x800062a4 | BELL   | [Bellcoin](https://bellcoin.web4u.jp)
 25718 | 0x80006476 | CHX    | [Own](https://wallet.weown.com)


### PR DESCRIPTION
In this PR, Pactus CoinType set to 21888 (hex: 0x80005580).
More information about Pactus is available here: https://pactus.org/
Github project: https://github.com/pactus-project/pactus