### PR TITLE
Updated Etho

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1240,7 +1240,7 @@ All these constants are used as hardened derivation.
 | 888888     | 0x800d9038                    | SEA     | Second Exchange Alliance          |
 | 1048576    | 0x80100000                    | AMAX    | Armonia Meta Chain                |
 | 1171337    | 0x8011df89                    | ILT     | iOlite                            |
-| 1313114    | 0x8014095a                    | ETHO    | Ether-1                           |
+| 1313114    | 0x8014095a                    | ETHO    | Etho Protocol                     |
 | 1313500    | 0x80140adc                    | XERO    | Xerom                             |
 | 1712144    | 0x801a2010                    | LAX     | LAPO                              |
 | 3924011    | 0x803be02b                    | EPK     | EPIK Protocol                     |


### PR DESCRIPTION
Ether-1 has been renamed to Etho Protocol in 2021