### PR TITLE
Add KILT live and testnet to slip-0044 coin type list.

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1111,6 +1111,7 @@ All these constants are used as hardened derivation.
 | 2022       | 0x800007e6                    | XHT     | Xinghuo Token                     |
 | 2048       | 0x80000800                    | MCASH   | MCashChain                        |
 | 2049       | 0x80000801                    | TRUE    | TrueChain                         |
+| 2086       | 0x80000826                    | KILT    | KILT Spiritnet                    |
 | 2109       | 0x8000083d                    | SAMA    | Exosama Network                   |
 | 2112       | 0x80000840                    | IoTE    | IoTE                              |
 | 2137       | 0x80000859                    | XRG     | Ergon                             |


### PR DESCRIPTION
This will add the KILT networks to the slip-0044 coin type list. KILT Spiritnet (which is the live network, a parachain of polkadot) has the same coin type number as it's parachain ID, following the example of Exosama Network and others. Our testnet has that number + 1. 