### PR TITLE
Add DeFiChain EVM Network to slip-0044

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1051,6 +1051,7 @@ All these constants are used as hardened derivation.
 | 1122       | 0x80000462                    | CMT     | CyberMiles Token                  |
 | 1128       | 0x80000468                    | ETSC    | Ethereum Social                   |
 | 1129       | 0x80000469                    | DFI     | DeFiChain                         |
+| 1130       | 0x8000046a                    | DFI     | DeFiChain EVM Network             |
 | 1137       | 0x80000471                    | $DAG    | Constellation Labs                |
 | 1145       | 0x80000479                    | CDY     | Bitcoin Candy                     |
 | 1155       | 0x80000483                    | EFI     | Efinity                           |


### PR DESCRIPTION
Adds the DeFiChain EVM Network to slip-0044 coin list.

Website: https://meta.defichain.com/