### PR TITLE
slip-0044: remove erroneous coin type

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1213,7 +1213,7 @@ All these constants are used as hardened derivation.
 | 22504      | 0x800057e8                    | PWR     | PWRcoin                           |
 | 25252      | 0x800062a4                    | BELL    | Bellcoin                          |
 | 25718      | 0x80006476                    | CHX     | Own                               |
-| 30001      | 0x80007531                    | FLR     | Flare                             |
+| 30001      | 0x80007531                    | ---     | reserved                          |
 | 31102      | 0x8000797e                    | ESN     | EtherSocial Network               |
 | 31337      | 0x80007a69                    |         | ThePower                          |
 | 33416      | 0x80008288                    | TEO     | Trust Eth reOrigin                |


### PR DESCRIPTION
PR #1363 added the wrong coin type for Flare Network. The official documentation states that coin type 60 is to be used: https://docs.flare.network/dev/reference/network-configs/#additional-notes. See also #1124.