### PR TITLE
Elrond is now MultiversX

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -536,7 +536,7 @@ All these constants are used as hardened derivation.
 | 505        | 0x800001f9                    | HASH    | Provenance                        |
 | 506        | 0x800001fa                    | CSPR    | Casper                            |
 | 507        | 0x800001fb                    | EARTH   | EARTH                             |
-| 508        | 0x800001fc                    | ERD     | Elrond                            |
+| 508        | 0x800001fc                    | EGLD    | MultiversX                        |
 | 509        | 0x800001fd                    | CHI     | Xaya                              |
 | 510        | 0x800001fe                    | KOTO    | Koto                              |
 | 511        | 0x800001ff                    | OTC     | θ                                 |


### PR DESCRIPTION
[`Elrond` is now `MultiversX`](https://twitter.com/beniaminmincu/status/1588162448103612416).

Furthermore, adjusted the coin symbol, from the old `ERD` to `EGLD` (the symbol was renamed back on 30th of July 2020).