### PR TITLE
SLIP-0044: add Age "coin"

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -781,7 +781,7 @@ All these constants are used as hardened derivation.
 | 750        | 0x800002ee                    | XPRT    | Persistence                       |
 | 751        | 0x800002ef                    |         |
 | 752        | 0x800002f0                    |         |
-| 753        | 0x800002f1                    |         |
+| 753        | 0x800002f1                    |         | Age Encryption                    |
 | 754        | 0x800002f2                    |         |
 | 755        | 0x800002f3                    |         |
 | 756        | 0x800002f4                    |         |


### PR DESCRIPTION
[Age](https://age-encryption.org) features public key encryption with X25519, this makes it possible to derive keys using SLIP-0010. As far as I know, only [this tool that I just wrote does it](https://lourkeur.github.io/age-hier/). There is no distributed ledger or asset involved. I chose 753 because Rome was founded in 753 BC.