### PR TITLE
Add Age Yubikey identities

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -782,7 +782,7 @@ All these constants are used as hardened derivation.
 | 751        | 0x800002ef                    |         |
 | 752        | 0x800002f0                    |         |
 | 753        | 0x800002f1                    |         | Age Encryption                    |
-| 754        | 0x800002f2                    |         |
+| 754        | 0x800002f2                    |         | Age Yubikey Encryption            |
 | 755        | 0x800002f3                    |         |
 | 756        | 0x800002f4                    |         |
 | 757        | 0x800002f5                    | HONEY   | HoneyWood                         |

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -781,8 +781,8 @@ All these constants are used as hardened derivation.
 | 750        | 0x800002ee                    | XPRT    | Persistence                       |
 | 751        | 0x800002ef                    |         |
 | 752        | 0x800002f0                    |         |
-| 753        | 0x800002f1                    |         | Age Encryption                    |
-| 754        | 0x800002f2                    |         | Age Yubikey Encryption            |
+| 753        | 0x800002f1                    |         | Age X25519 Encryption             |
+| 754        | 0x800002f2                    |         | Age NIST Encryption               |
 | 755        | 0x800002f3                    |         |
 | 756        | 0x800002f4                    |         |
 | 757        | 0x800002f5                    | HONEY   | HoneyWood                         |


### PR DESCRIPTION
The [Yubikey plugin for Age](https://github.com/str4d/age-plugin-yubikey) uses NIST P-256 (or P-384) keypairs. This is different than the native Age keypairs which are X25519. Having a SLIP-0044 would allow derivation and also ENS integration, following the model of https://github.com/ensdomains/address-encoder/pull/378.