### PR TITLE
Add human readable part nois for Nois Network

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -128,6 +128,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | Namecoin                 | `nc`          | `tn`     | `ncrt`      |
 | Neutron                  | `neutron`     |          |             |
 | Nexa                     | `nexa`        |`nexatest`| `nexareg`   |
+| Nois                     | `nois`        |          |             |
 | Nomic                    | `nomic`       |          |             |
 | Nyx                      | `n`           |          |             |
 | Oasis Network            | `oasis`       | `oasis`  |             |


### PR DESCRIPTION
[Nois Network](http://nois.network) uses the prefix `nois`.

Thank you!