### PR TITLE
feat(`slip-0173`): add KYVE

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -107,6 +107,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | Kira Network             | `kira`        |          |             |
 | Konstellation            | `darc`        |          |             |
 | Kujira                   | `kujira`      |          |             |
+| KYVE                     | `kyve`        |          |             |
 | Lambda                   | `lamb`        |          |             |
 | LatticeX                 | `pla`         | `plt`    |             |
 | LikeCoin                 | `like`        |          |             |


### PR DESCRIPTION
[KYVE](https://kyve.network) used Bech32 prefix `kyve`.