### PR TITLE
Update slip-0044.md

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -466,7 +466,7 @@ All these constants are used as hardened derivation.
 | 435        | 0x800001b3                    | PCN     | Peepcoin                          |
 | 436        | 0x800001b4                    | NCH     | NetCloth                          |
 | 437        | 0x800001b5                    | ICU     | CHIPO                             |
-| 438        | 0x800001b6                    | LN      | LINK                              |
+| 438        | 0x800001b6                    | FNSA    | FINSCHIA                          |
 | 439        | 0x800001b7                    | DTP     | DeVault Token Protocol            |
 | 440        | 0x800001b8                    | BTCR    | Bitcoin Royale                    |
 | 441        | 0x800001b9                    | AERGO   | AERGO                             |


### PR DESCRIPTION
Renaming LINK Coin and Symbol to `FNSA` and `FINSCHIA`
