### PR TITLE
SLIP-0173: add UnUniFi

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -196,6 +196,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | Ulas                     | `ulas`        |          |             |
 | Umee                     | `umee`        |          |             |
 | Unification              | `und`         |          |             |
+| UnUniFi                  | `ununifi`     |          |             |
 | Unit-e                   | `ue`          | `tue`    | `uert`      |
 | Uptick                   | `uptick`      |          |             |
 | Vertcoin                 | `vtc`         | `tvtc`   |             |


### PR DESCRIPTION
- `ununifi` is the mainnet of UnUniFi protocol.
- https://ununifi.io/