### PR TITLE
update(slip-0044): moonsama network

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1131,6 +1131,7 @@ All these constants are used as hardened derivation.
 | 2125       | 0x8000084d                    | BAY     | BitBay                            |
 | 2137       | 0x80000859                    | XRG     | Ergon                             |
 | 2182       | 0x80000888                    | CHZ     | Chiliz                            |
+| 2199       | 0x80000897                    | SAMA    | Moonsama Network                  |
 | 2221       | 0x800008ad                    | ASK     | ASK                               |
 | 2285       | 0x800008ed                    |         | Qiyi Chain                        |
 | 2301       | 0x800008fd                    | QTUM    | QTUM                              |
@@ -1138,7 +1139,6 @@ All these constants are used as hardened derivation.
 | 2303       | 0x800008ff                    | GXC     | GXChain                           |
 | 2304       | 0x80000900                    | CRP     | CranePay                          |
 | 2305       | 0x80000901                    | ELA     | Elastos                           |
-| 2309       | 0x80000905                    | SAMA    | Moonsama Network                  |
 | 2338       | 0x80000922                    | SNOW    | Snowblossom                       |
 | 2365       | 0x8000093d                    | XIN     | Mixin                             |
 | 2500       | 0x800009c4                    | NEXI    | Nexi                              |


### PR DESCRIPTION
Chain ID had to be changed from 2309 to 2199 because of a clash
https://github.com/ethereum-lists/chains/pull/3099
https://github.com/paritytech/ss58-registry/pull/177