### PR TITLE
codex32 hrps for slip-0173

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -233,6 +233,18 @@ other entries use Bech32.
 |       | `uivk` (m)                 | `uivktest` (m)             | `uivkregtest` (m)             |
 |       | `uview` (m)                | `uviewtest` (m)            | `uviewregtest` (m)            |
 
+## Uses of codex32
+
+The codex32 format is used to store master secret data. It features an extended
+checksum versus the one used in Bech32 in order to support enhanced error
+correction. Codex32 uses the same notion of a human-readable part and the same
+set of 32 characters as other Bech32 formats.
+
+| Application          | Human-readable part  |
+| -------------------- | -------------------- |
+| CLN's HSM secret     | `cl`                 |
+| BIP-0032 master seed | `ms`                 |
+
 ## Libraries
 
 - [Reference Implementations](https://github.com/sipa/bech32/tree/master/ref)
@@ -241,3 +253,4 @@ other entries use Bech32.
 
 - [BIP-0173: Base32 address format for native v0-16 witness outputs](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki)
 - [BIP-0350: Bech32m format for v1+ witness addresses](https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki)
+- [BIP-0093: codex32: Checksummed SSSS-aware BIP32 seeds](https://github.com/bitcoin/bips/blob/master/bip-0093.mediawiki)


### PR DESCRIPTION
Codex32 applications uses the same sort of hrp/bech32 format that BIP-0173 uses.

The use of codex32 for master seeds, using the `ms` prefix, is described in BIP-0093.

CLN v23.08 is using the `cl` prefix for its codex32 HSM secret recovery format.