### PR TITLE
feat(slip-0044): dHealth

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1303,6 +1303,7 @@ All these constants are used as hardened derivation.
 | 7825267    | 0x80776773                    | OBSR    | OBServer                          |
 | 8163271    | 0x807c8fc7                    | AFS     | ANFS                              |
 | 15118976   | 0x80e6b280                    | XDS     | XDS                               |
+| 29112017   | 0x81bc36d1                    | DHP     | dHealth                           |
 | 61717561   | 0x83adbc39                    | AQUA    | Aquachain                         |
 | 88888888   | 0x854c5638                    | HATCH   | Hatch                             |
 | 91927009   | 0x857ab1e1                    | kUSD    | kUSD                              |


### PR DESCRIPTION
**Coin name:**
dHealth

**Coin symbol:**
DHP

**A brief description of the coin and the blockchain it operates on:**
dHealth is a layer-one blockchain centered around healthcare use-cases as well as health in general.
The dHealth token(DHP) is present on three blockchains—native dHealth, Ethereum and BNB chain.
Staking of the DHP token is only possible on the native chain.

**Any relevant links or references:**
[Web](https://www.dhealth.com/)
[X Application](https://twitter.com/dHealth_Network)