### PR TITLE
Add Enjin Coin

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1059,7 +1059,7 @@ All these constants are used as hardened derivation.
 | 1130       | 0x8000046a                    | DFI     | DeFiChain EVM Network             |
 | 1137       | 0x80000471                    | $DAG    | Constellation Labs                |
 | 1145       | 0x80000479                    | CDY     | Bitcoin Candy                     |
-| 1155       | 0x80000483                    | EFI     | Efinity                           |
+| 1155       | 0x80000483                    | ENJ     | Enjin Coin                        |
 | 1170       | 0x80000492                    | HOO     | Hoo Smart Chain                   |
 | 1234       | 0x800004d2                    | ALPH    | Alephium                          |
 | 1236       | 0x800004d4                    |         | Masca                             |


### PR DESCRIPTION
Hello, I'm a developer at Enjin and we will be removing Efinity in favor of Enjin Blockchain. We would like to keep the 1155 id as that's a special number for us.