### PR TITLE
slip-0173: Update shentu `bech32_prefix`

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -187,7 +187,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | Sentinel                 | `sent`        |          |             |
 | Sigma Six Sports         | `sge`         |          |             |
 | ShareLedger              | `shareledger` |          |             |
-| Shentu                   | `certik`      |          |             |
+| Shentu                   | `shentu`      |          |             |
 | Shimmer                  | `smr`         | `rms`    |             |
 | Sifchain                 | `sif`         |          |             |
 | Sommelier                | `somm`        |          |             |


### PR DESCRIPTION
Release Details: https://github.com/shentufoundation/shentu/blob/master/CHANGELOG.md#v280---09-12-2023