### PR TITLE
Renaming Six Sigma Sports

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -185,7 +185,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | Secret Network           | `secret`      |          |             |
 | Sei                      | `sei`         |          |             |
 | Sentinel                 | `sent`        |          |             |
-| Sigma Six Sports         | `sge`         |          |             |
+| SGE Network              | `sge`         |          |             |
 | ShareLedger              | `shareledger` |          |             |
 | Shentu                   | `shentu`      |          |             |
 | Shimmer                  | `smr`         | `rms`    |             |


### PR DESCRIPTION
Renaming Six Sigmasports to SGE Network