### PR TITLE
Add Kudos Setler to slip-0044.md

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1064,6 +1064,7 @@ All these constants are used as hardened derivation.
 | 1234       | 0x800004d2                    | ALPH    | Alephium                          |
 | 1236       | 0x800004d4                    |         | Masca                             |
 | 1237       | 0x800004d5                    |         | Nostr                             |
+| 1280       | 0x80000500                    |         | Kudos Setler                      |
 | 1284       | 0x80000504                    | GLMR    | Moonbeam                          |
 | 1285       | 0x80000505                    | MOVR    | Moonriver                         |
 | 1298       | 0x80000512                    | WPC     | Wpc                               |


### PR DESCRIPTION
This notes that [Kudos](https://www.kudos.community) [Setler](https://www.setler.app) is using coinId 1280 in its wallet.
