### PR TITLE
Slip-0044: Add Mintlayer to registered coin types

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1245,6 +1245,7 @@ All these constants are used as hardened derivation.
 | 19165      | 0x80004add                    | SAFE    | Safecoin                          |
 | 19167      | 0x80004adf                    | FLUX    | Flux                              |
 | 19169      | 0x80004ae1                    | RITO    | Ritocoin                          |
+| 19788      | 0x80004d4c                    | ML      | Mintlayer                         |
 | 20036      | 0x80004e44                    | XND     | ndau                              |
 | 21004      | 0x8000520c                    | C4EI    | c4ei                              |
 | 21888      | 0x80005580                    | PAC     | Pactus                            |


### PR DESCRIPTION
Hello

We would like to add the Mintlayer coin to the slip-0044 list. I couldn't find a documentation for this process, and I was told a PR is in order.

I saw the requirement to have a software wallet that uses this code. The repository for Mintlayer can be found in: https://github.com/mintlayer/mintlayer-core

In it, there's a the `wallet-cli` application and the `wallet-address-generator` that use the reserved code. The address generator can be run with the command: `cargo run --bin wallet-address-generator`. It will generate addresses for mainnet.

All the best.