### PR TITLE
Fix typo in SLIP-44

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1041,7 +1041,6 @@ All these constants are used as hardened derivation.
 | 1010       | 0x800003f2                    | HT      | Huobi ECO Chain                   |
 | 1011       | 0x800003f3                    | ELV     | Eluvio                            |
 | 1013       | 0x800003f5                    | BIC     | Beincrypto                        |
-| 1016       | 0x800003f8                    | CORE    | Core                              |
 | 1020       | 0x800003fc                    | EVC     | Evrice                            |
 | 1022       | 0x800003fe                    | XRD     | Radix DLT                         |
 | 1023       | 0x800003ff                    | ONE     | HARMONY-ONE (Legacy)              |
@@ -1053,6 +1052,7 @@ All these constants are used as hardened derivation.
 | 1032       | 0x80000408                    | BTCR    | BTCR                              |
 | 1042       | 0x80000412                    | MFID    | Moonfish ID                       |
 | 1111       | 0x80000457                    | BBC     | Big Bitcoin                       |
+| 1116       | 0x8000045C                    | CORE    | Core                              |
 | 1120       | 0x80000460                    | RISE    | RISE                              |
 | 1122       | 0x80000462                    | CMT     | CyberMiles Token                  |
 | 1128       | 0x80000468                    | ETSC    | Ethereum Social                   |

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1041,6 +1041,7 @@ All these constants are used as hardened derivation.
 | 1010       | 0x800003f2                    | HT      | Huobi ECO Chain                   |
 | 1011       | 0x800003f3                    | ELV     | Eluvio                            |
 | 1013       | 0x800003f5                    | BIC     | Beincrypto                        |
+| 1016       | 0x800003f8                    | CORE    | Core                              |
 | 1020       | 0x800003fc                    | EVC     | Evrice                            |
 | 1022       | 0x800003fe                    | XRD     | Radix DLT                         |
 | 1023       | 0x800003ff                    | ONE     | HARMONY-ONE (Legacy)              |

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1041,7 +1041,6 @@ All these constants are used as hardened derivation.
 | 1010       | 0x800003f2                    | HT      | Huobi ECO Chain                   |
 | 1011       | 0x800003f3                    | ELV     | Eluvio                            |
 | 1013       | 0x800003f5                    | BIC     | Beincrypto                        |
-| 1016       | 0x800003f8                    | CORE    | Core                              |
 | 1020       | 0x800003fc                    | EVC     | Evrice                            |
 | 1022       | 0x800003fe                    | XRD     | Radix DLT                         |
 | 1023       | 0x800003ff                    | ONE     | HARMONY-ONE (Legacy)              |


### PR DESCRIPTION
Update Core chain ID to `1116`, the correct chain ID as seen in [chainlist](https://chainlist.org/chain/1116).