### PR TITLE
Renamed FCTID to ACME

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -309,7 +309,7 @@ All these constants are used as hardened derivation.
 | 278        | 0x80000116                    | BOLI    | Bolivarcoin                       |
 | 279        | 0x80000117                    | RIL     | Rilcoin                           |
 | 280        | 0x80000118                    | HTR     | Hathor Network                    |
-| 281        | 0x80000119                    | FCTID   | Factom ID                         |
+| 281        | 0x80000119                    | ACME    | Accumulate                        |
 | 282        | 0x8000011a                    | BRAVO   | BRAVO                             |
 | 283        | 0x8000011b                    | ALGO    | Algorand                          |
 | 284        | 0x8000011c                    | BZX     | Bitcoinzero                       |


### PR DESCRIPTION
The Factom protocol went through a hard fork October 2022 and rebranded to the Accumulate Network.  FCT remains the same and the FCTID (Factom ID) was repurposed to ACME and adopted as the coin type of Accumulate.