### PR TITLE
Add blucrates (BCS)

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -755,7 +755,7 @@ All these constants are used as hardened derivation.
 | 724        | 0x800002d4                    | XVC     | Vanillacash                       |
 | 725        | 0x800002d5                    | MCX     | MultiCash                         |
 | 726        | 0x800002d6                    |         |
-| 727        | 0x800002d7                    |         |
+| 727        | 0x800002d7                    | BLU     | BluCrates                         |
 | 728        | 0x800002d8                    |         |
 | 729        | 0x800002d9                    |         |
 | 730        | 0x800002da                    | HEALIOS | Tenacity                          |


### PR DESCRIPTION
# Slip0044 PR: Add blucrates (BLU)

## Description

This PR adds the blucrates (BLU) coin to the slip0044 registry.

## Details

- **Number:** 727
- **Symbol:** BLU
- **Hex Code:** 0x800002d7

## Motivation

Provide support for the blucrates (BLU) coin in the slip0044 registry to enhance compatibility with various wallets and tools.

## References

- Slip0044: https://github.com/satoshilabs/slips/blob/master/slip-0044.md
