### PR TITLE
Add BXN to the list

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1177,6 +1177,7 @@ All these constants are used as hardened derivation.
 | 4343       | 0x800010f7                    | XYM     | Symbol                            |
 | 4444       | 0x8000115c                    | C4E     | Chain4Energy                      |
 | 4919       | 0x80001337                    | XVM     | Venidium                          |
+| 4999       | 0x80001387                    | BXN     | BlackFort Exchange Network        |
 | 5006       | 0x8000138e                    | SBC     | Senior Blockchain                 |
 | 5248       | 0x80001480                    | FIC     | FIC                               |
 | 5353       | 0x800014e9                    | HNS     | Handshake                         |


### PR DESCRIPTION
# Slip0044 PR: Add BlackFort Exchange Network (BXN)
## Description
This PR adds BlackFort Exchange Network (BXN) coin to the slip0044 registry.

## Details
- Number: 4999
- Symbol: BXN
- Hex Code: 0x80001387
## Motivation
Provide support for BlackFort Exchange Network (BXN) coin in the slip0044 registry to enhance compatibility with various wallets and tools.

## References
Slip0044: https://github.com/satoshilabs/slips/blob/master/slip-0044.md