### PR TITLE
Add Nym token

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -161,6 +161,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | Noble                    | `noble`       |          |             |
 | Nois                     | `nois`        |          |             |
 | Nomic                    | `nomic`       |          |             |
+| Nym                      | `n`           |          |             |
 | Nyx                      | `n`           |          |             |
 | Oasis Network            | `oasis`       | `oasis`  |             |
 | Octa                     | `octa`        |          |             |


### PR DESCRIPTION
Add Nym token. The Nym exist on the Nyx chain next to the Nyx token, and is using the same Address format.