### PR TITLE
Fix algorithm for master key derivation

### DIFF
--- a/slip-0010.md
+++ b/slip-0010.md
@@ -63,7 +63,7 @@ optional passphrase.
 2. Split I into two 32-byte sequences, I<sub>L</sub> and I<sub>R</sub>.
 3. Use parse<sub>256</sub>(I<sub>L</sub>) as master secret key, and I<sub>R</sub> as master chain code.
 4. If curve is not ed25519 and I<sub>L</sub> is 0 or ≥ n (invalid key):
-    * Set S := I and continue at step 2.
+    * Set S := I and restart at step 1.
 
 The supported curves are
 


### PR DESCRIPTION
This fixes the broken indexation in the master key derivation algorithm. The error was introduced in commit 5b7a092