### PR TITLE
add lava to slip-0173

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -135,6 +135,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | KYVE                     | `kyve`        |          |             |
 | Lambda                   | `lamb`        |          |             |
 | LatticeX                 | `pla`         | `plt`    |             |
+| Lava                     | `lava@`       | `lava@`  |             |
 | LikeCoin                 | `like`        |          |             |
 | Litecoin                 | `ltc`         | `tltc`   | `rltc`      |
 | Logos                    | `logos`       |          |             |


### PR DESCRIPTION
add the Lava blockchain to the slip

easy to verify with:
curl -X 'GET' \
  'https://rest-public-rpc-testnet2.lavanet.xyz/cosmos/auth/v1beta1/accounts' \
  -H 'accept: application/json'
  
or an explorer:
https://lava.explorers.guru/validators