### PR TITLE
add lava to slip-0173

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -135,6 +135,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | KYVE                     | `kyve`        |          |             |
 | Lambda                   | `lamb`        |          |             |
 | LatticeX                 | `pla`         | `plt`    |             |
+| Lava                     | `lava@`       | `lava@`  |             |
 | LikeCoin                 | `like`        |          |             |
 | Litecoin                 | `ltc`         | `tltc`   | `rltc`      |
 | Logos                    | `logos`       |          |             |


### PR DESCRIPTION
add the Lava blockchain to the slip

@prusnak closed the previous PR saying 'lava@' hrp for bech32 is invalid, please refer me to the sources defining the restriction

'@' is within the range 33-126 

afaik:
https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki quote:
"The human-readable part, which is intended to convey the type of data, or anything else that is relevant to the reader. This part MUST contain 1 to 83 US-ASCII characters, with each character having a value in the range [33-126]. HRP validity may be further restricted by specific applications.",

easy to verify with:
curl -X 'GET'
'https://rest-public-rpc-testnet2.lavanet.xyz/cosmos/auth/v1beta1/accounts'
-H 'accept: application/json'

or an explorer:
https://lava.explorers.guru/validators

