### PR TITLE
Update slip-0044.md

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -844,7 +844,7 @@ All these constants are used as hardened derivation.
 | 813        | 0x8000032d                    | MEER    | Qitmeer                           |
 | 814        | 0x8000032e                    |         |
 | 815        | 0x8000032f                    |         |
-| 816        | 0x80000330                    |         |
+| 816        | 0x80000330                    | FSC     | FSC
 | 817        | 0x80000331                    |         |
 | 818        | 0x80000332                    | VET     | VeChain Token                     |
 | 819        | 0x80000333                    | REEF    | Reef                              |


### PR DESCRIPTION
Number:  SLIP-0044
Title:   Registered coin types for BIP-0044
Type:    Standard
Status:  Active
Authors: zhiyong huang <1109007763@qq.com>
Created: 2024-01-22