### PR TITLE
SLIP-0173: Add HRPs used by Lightning Network and age

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -254,7 +254,7 @@ other entries use Bech32. `[text]` indicates variable content in the human-reada
 |                   | `age-secret-key-`              |
 |                   | `age1[name]`                   |
 |                   | `age-plugin-[name]-`           |
-| Lightning Network | `ln[BIP-0173 currency prefix]` |
+| Lightning Network | `ln[currency prefix + amount]` |
 | Zcash             | `zs`                           | `ztestsapling`             | `zregtestsapling`             |
 |                   | `zivks`                        | `zivktestsapling`          | `zivkregtestsapling`          |
 |                   | `zxviews`                      | `zxviewtestsapling`        | `zxviewregtestsapling`        |

--- a/slip-0173.md
+++ b/slip-0173.md
@@ -246,19 +246,24 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 
 The following human-readable parts are registered for formats using Bech32 or Bech32m
 that are not compatible with Segwit. Entries annotated with "(m)" use Bech32m [BIP-0350];
-other entries use Bech32.
+other entries use Bech32. `[text]` indicates variable content in the human-readable part.
 
-| Coin  | Mainnet                    | Testnet                    | Regtest                       |
-| ----- | -------------------------- | -------------------------- | ----------------------------- |
-| Zcash | `zs`                       | `ztestsapling`             | `zregtestsapling`             |
-|       | `zivks`                    | `zivktestsapling`          | `zivkregtestsapling`          |
-|       | `zxviews`                  | `zxviewtestsapling`        | `zxviewregtestsapling`        |
-|       | `zxsprout`                 | `zxtestsprout`             | `zxregtestsprout`             |
-|       | `secret-spending-key-main` | `secret-spending-key-test` | `secret-spending-key-regtest` |
-|       | `secret-extended-key-main` | `secret-extended-key-test` | `secret-extended-key-regtest` |
-|       | `u` (m)                    | `utest` (m)                | `uregtest` (m)                |
-|       | `uivk` (m)                 | `uivktest` (m)             | `uivkregtest` (m)             |
-|       | `uview` (m)                | `uviewtest` (m)            | `uviewregtest` (m)            |
+| Project           | Mainnet / Production           | Testnet                    | Regtest                       |
+| ----------------- | ------------------------------ | -------------------------- | ----------------------------- |
+| age               | `age`                          |
+|                   | `age-secret-key-`              |
+|                   | `age1[name]`                   |
+|                   | `age-plugin-[name]-`           |
+| Lightning Network | `ln[BIP-0173 currency prefix]` |
+| Zcash             | `zs`                           | `ztestsapling`             | `zregtestsapling`             |
+|                   | `zivks`                        | `zivktestsapling`          | `zivkregtestsapling`          |
+|                   | `zxviews`                      | `zxviewtestsapling`        | `zxviewregtestsapling`        |
+|                   | `zxsprout`                     | `zxtestsprout`             | `zxregtestsprout`             |
+|                   | `secret-spending-key-main`     | `secret-spending-key-test` | `secret-spending-key-regtest` |
+|                   | `secret-extended-key-main`     | `secret-extended-key-test` | `secret-extended-key-regtest` |
+|                   | `u` (m)                        | `utest` (m)                | `uregtest` (m)                |
+|                   | `uivk` (m)                     | `uivktest` (m)             | `uivkregtest` (m)             |
+|                   | `uview` (m)                    | `uviewtest` (m)            | `uviewregtest` (m)            |
 
 ## Uses of codex32
 


### PR DESCRIPTION
Lightning Network prefix is used for Lightning Invoices ([BOLT 11](https://github.com/lightning/bolts/blob/master/11-payment-encoding.md)).

age prefixes are used for encodings of [native](https://c2sp.org/age#the-x25519-recipient-type) and [plugin](https://c2sp.org/age-plugin#mapping-recipients-and-identities-to-plugin-binaries) recipients and identities.