### PR TITLE
add QI token for Quai Network

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -844,7 +844,7 @@ All these constants are used as hardened derivation.
 | 813        | 0x8000032d                    | MEER    | Qitmeer                           |
 | 814        | 0x8000032e                    |         |
 | 815        | 0x8000032f                    |         |
-| 816        | 0x80000330                    | FSC     | FSC
+| 816        | 0x80000330                    | FSC     | FSC                               |
 | 817        | 0x80000331                    |         |
 | 818        | 0x80000332                    | VET     | VeChain Token                     |
 | 819        | 0x80000333                    | REEF    | Reef                              |
@@ -879,7 +879,7 @@ All these constants are used as hardened derivation.
 | 848        | 0x80000350                    | BIR     | Birake                            |
 | 849        | 0x80000351                    | MOBIC   | MobilityCoin                      |
 | 850        | 0x80000352                    | FLS     | Flits                             |
-| 851        | 0x80000353                    | FRECO   | Freco
+| 851        | 0x80000353                    | FRECO   | Freco                             |
 | 852        | 0x80000354                    | DSM     | Desmos                            |
 | 853        | 0x80000355                    | PRCY    | PRCY Coin                         |
 | 854        | 0x80000356                    |         |
@@ -997,7 +997,7 @@ All these constants are used as hardened derivation.
 | 966        | 0x800003c6                    | MATIC   | Matic                             |
 | 967        | 0x800003c7                    |         |
 | 968        | 0x800003c8                    | UNW     | UNW                               |
-| 969        | 0x800003c9                    |         |
+| 969        | 0x800003c9                    | QI      | Quai Network                      |
 | 970        | 0x800003ca                    | TWINS   | TWINS                             |
 | 971        | 0x800003cb                    |         |
 | 972        | 0x800003cc                    |         |


### PR DESCRIPTION
Added QI token to slip-0044 as a part of Quai Network.

Quai Network is a layer 1 which has an interchangable two token system with separate ledgers. Due to this we need 2 slip registrations - 994 for $Quai and we request 969 for $Qi. This is a necessary requirement for wallet implementation on the network.

You can read more about the two token system [here](https://qu.ai/docs/learn/tokenomics/tokenomics-overview/)

About Quai Network:
[Website](https://qu.ai/)
[X](https://twitter.com/QuaiNetwork)