### PR TITLE
SLIP-0048: add Keet  type

### DIFF
--- a/slip-0048.md
+++ b/slip-0048.md
@@ -140,6 +140,7 @@ Index          | Network      | Roles
 0x0000000c     | DECENT       | `0x0`: owner, `0x1`: active, `0x3`: memo
 0x0000000d     | Hive         | `0x0`: owner, `0x1`: active, `0x3`: memo, `0x4`: posting
 0x00001388     | Vet The Vote | `0x0`: owner, `0x1`: active, `0x3`: memo, `0x4`: posting, `0x5`: comms
+0x000014da     | Keet         | `0x0`: owner
 
 ## Examples
 


### PR DESCRIPTION
Keet is a DHT-based p2p distributed chat protocol with self sovreignty at it's core. Users are identified over the network by ed25519 public keys.

In order to support for cross platform identities, keys will derived from a BIP-39 menmonic via SLIP-10 key derivation. This allows users to be able to recover their network identity in case any/all devices are compromised. Furthermore, existing hardware wallet owners may simply derive their identity from their existing secret.

The type `0x14da == 5338` spells `KEET` on an alphanumeric keypad.

Note that we are not a Graphene-based blockchain, nor do we have any coin associated with our product. SLIP-48 was chosen as our account hierarchies align, with only the single `owner` role.

#### links:
- https://keet.io/
- https://pears.com/