### PR TITLE
Update slip-0173.md

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -162,6 +162,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | Myriad                   | `my`          | `tm`     |             |
 | Mythos                   | `mythos`      |          |             |
 | Namecoin                 | `nc`          | `tn`     | `ncrt`      |
+| Neutaro                  | `neutaro`     |          |             |
 | Neutron                  | `neutron`     |          |             |
 | Nexa                     | `nexa`        |`nexatest`| `nexareg`   |
 | Nibiru                   | `nibi`        |          |             |


### PR DESCRIPTION
Add Neutaro ( https://neutaro.com/ ) to slip-0173 as requested by https://github.com/JeremyParish69 in our request to be added to the chain-registry.