### PR TITLE
Update Radiant symbol

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -540,7 +540,7 @@ All these constants are used as hardened derivation.
 | 509        | 0x800001fd                    | CHI     | Xaya                              |
 | 510        | 0x800001fe                    | KOTO    | Koto                              |
 | 511        | 0x800001ff                    | OTC     | θ                                 |
-| 512        | 0x80000200                    | XRD     | Radiant                           |
+| 512        | 0x80000200                    | RXD     | Radiant                           |
 | 513        | 0x80000201                    | SEELEN  | Seele-N                           |
 | 514        | 0x80000202                    | AETH    | AETH                              |
 | 515        | 0x80000203                    | DNA     | Idena                             |


### PR DESCRIPTION
Update of the misspelled Radiant symbol.

It is RXD and not XRD

https://radiantblockchain.org