### PR TITLE
shido added

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -208,6 +208,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | SGE Network              | `sge`         |          |             |
 | ShareLedger              | `shareledger` |          |             |
 | Shentu                   | `shentu`      |          |             |
+| Shido                    | `shido`       |          |             |
 | Shimmer                  | `smr`         | `rms`    |             |
 | Sifchain                 | `sif`         |          |             |
 | SIX Protocol             | `6x`          |          |             |


### PR DESCRIPTION
shido added to the  registered human-readable parts for usage in Bech32 encoding of witness programs.