### PR TITLE
Update slip-0173.md

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -215,6 +215,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | Sifchain                 | `sif`         |          |             |
 | SIX Protocol             | `6x`          |          |             |
 | Sommelier                | `somm`        |          |             |
+| Sonr                     | `idx`         |          |             |
 | Source                   | `source`      |          |             |
 | Spacemesh                | `sm`          | `stest`  |             |
 | StaFiHub                 | `stafi`       |          |             |


### PR DESCRIPTION
Add Sonr's mainnet bech32 encoding. [Sonr Docs](https://docs.didao.org)
