### PR TITLE
Update slip-0173.md

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -170,6 +170,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | Neutron                  | `neutron`     |          |             |
 | Nexa                     | `nexa`        |`nexatest`| `nexareg`   |
 | Nibiru                   | `nibi`        |          |             |
+| Nim                      | `nim`         |          |             |
 | Noble                    | `noble`       |          |             |
 | Nois                     | `nois`        |          |             |
 | Nomic                    | `nomic`       |          |             |


### PR DESCRIPTION
Add Nim Network [prefix 'nim']


Nim is the first "roll-up" on Dymension network.