### PR TITLE
Add Fren.ai to slip-0173.md

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -75,7 +75,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | ConsciousDAO             | `cvn`         |          |             |
 | Coreum                   | `core`        |`testcore`|             |
 | Cosmos Hub               | `cosmos`      |          |             |
-| Coss Chain               | `coss`        | `tcoss`   |             |
+| Coss Chain               | `coss`        | `tcoss`  |             |
 | CPUchain                 | `cpu`         | `tcpu`   | `rcpu`      |
 | Craft Economy            | `craft`       |          |             |
 | CranePay                 | `cp`          | `cpt`    | `cpr`       |
@@ -103,6 +103,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | Fetch                    | `fetch`       |          |             |
 | Finschia                 | `link`        | `tlink`  |             |
 | FirmaChain               | `firma`       |          |             |
+| Fren.ai                  | `fren`        | `fren-1` |             |
 | FujiCoin                 | `fc`          | `tf`     | `fcrt`      |
 | Furya                    | `furya`       |          |             |
 | f(x)Core                 | `fx`          |          |             |


### PR DESCRIPTION
Registered Fren.ai's human-readable part for Bech32 encoding.