### PR TITLE
Update `RSK` to `Rootstock`

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -165,7 +165,7 @@ All these constants are used as hardened derivation.
 | 134        | 0x80000086                    | LSK     | Lisk                              |
 | 135        | 0x80000087                    | STEEM   | Steem                             |
 | 136        | 0x80000088                    | XZC     | ZCoin                             |
-| 137        | 0x80000089                    | RBTC    | RSK                               |
+| 137        | 0x80000089                    | RBTC    | Rootstock                         |
 | 138        | 0x8000008a                    |         | Giftblock                         |
 | 139        | 0x8000008b                    | RPT     | RealPointCoin                     |
 | 140        | 0x8000008c                    | LBC     | LBRY Credits                      |


### PR DESCRIPTION
### Description
This PR updates `Rsk` coin type to `Rootstock` as its rebranded https://rootstock.io/

### Why
To reflect right network name for Rootstock for developers, partners and dApps. 

Would be great if this pull request get considered. Feel free to let me know if further information is required.