### PR TITLE
Add Bech32 for BlockX

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -55,6 +55,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | BitSong                  | `bitsong`     |          |             |
 | BitZeny                  | `bz`          | `tz`     | `rz`        |
 | Blacknet                 | `blacknet`    |          | `rblacknet` |
+| BlockX                   | `blockx`      | `blockx` |             |
 | Bluzelle                 | `bluzelle`    |          |             |
 | bostrom                  | `bostrom`     |          |             |
 | Canto                    | `canto`       |          |             |

--- a/slip-0173.md
+++ b/slip-0173.md
@@ -55,7 +55,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | BitSong                  | `bitsong`     |          |             |
 | BitZeny                  | `bz`          | `tz`     | `rz`        |
 | Blacknet                 | `blacknet`    |          | `rblacknet` |
-| BlockX                   | `blockx`      | `blockx` |             |
+| BlockX                   | `blockx`      |          |             |
 | Bluzelle                 | `bluzelle`    |          |             |
 | bostrom                  | `bostrom`     |          |             |
 | Canto                    | `canto`       |          |             |


### PR DESCRIPTION
- Register the human-readable parts for usage in Bech32 for BlockX Network/Chain.