### PR TITLE
Add Bech32 for Joltify

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -136,6 +136,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | Impact Hub               | `ixo`         |          |             |
 | Jackal                   | `jkl`         |          |             |
 | Juno                     | `juno`        |          |             |
+| Joltify                  | `jolt`        |          |             |
 | Kava                     | `kava`        |          |             |
 | Ki                       | `ki`          |          |             |
 | Kira Network             | `kira`        |          |             |


### PR DESCRIPTION
Register the human-readable parts for usage in Bech32 for Joltify Chain.