### PR TITLE
Update slip-0044.md

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1169,6 +1169,7 @@ All these constants are used as hardened derivation.
 | 3377       | 0x80000d31                    | ROI     | ROIcoin                           |
 | 3381       | 0x80000d35                    | DYN     | Dynamic                           |
 | 3383       | 0x80000d37                    | SEQ     | Sequence                          |
+| 3434       | 0x80000d6a                    | PEPE    | Pepecoin Core                     |
 | 3501       | 0x80000dad                    | JFIN    | JFIN Coin                         |
 | 3552       | 0x80000de0                    | DEO     | Destocoin                         |
 | 3564       | 0x80000dec                    | DST     | DeStream                          |


### PR DESCRIPTION
Add coin value path for Pepecoin Core.

This coin forked from Dogecoin, so its implementation is similar to that of Dogecoin Core.

https://github.com/pepecoinppc/pepecoin/pull/67