### PR TITLE
Add Bullions Smart Chain to SLIP-44 Registry

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1226,7 +1226,7 @@ All these constants are used as hardened derivation.
 | 8444       | 0x800020fc                    | XCH     | Chia                              |
 | 8520       | 0x80002148                    | ---     | reserved                          |
 | 8680       | 0x800021e8                    | PLMNT   | Planetmint                        |
-| 8732       | 0x8000221C                    | BLN     | Bullions                          |
+| 8732       | 0x8000221c                    | BLN     | Bullions                          |
 | 8866       | 0x800022a2                    | GGX     | Golden Gate                       |
 | 8886       | 0x800022b6                    | GGXT    | Golden Gate Sydney                |
 | 8888       | 0x800022b8                    | SBTC    | Super Bitcoin                     |

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1226,7 +1226,7 @@ All these constants are used as hardened derivation.
 | 8444       | 0x800020fc                    | XCH     | Chia                              |
 | 8520       | 0x80002148                    | ---     | reserved                          |
 | 8680       | 0x800021e8                    | PLMNT   | Planetmint                        |
-| 8732       | 0x80002214                    | BLN     | Bullions                          |
+| 8732       | 0x8000221C                    | BLN     | Bullions                          |
 | 8866       | 0x800022a2                    | GGX     | Golden Gate                       |
 | 8886       | 0x800022b6                    | GGXT    | Golden Gate Sydney                |
 | 8888       | 0x800022b8                    | SBTC    | Super Bitcoin                     |

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1226,7 +1226,7 @@ All these constants are used as hardened derivation.
 | 8444       | 0x800020fc                    | XCH     | Chia                              |
 | 8520       | 0x80002148                    | ---     | reserved                          |
 | 8680       | 0x800021e8                    | PLMNT   | Planetmint                        |
-| 8732       | 0x80008732                    | BLN     | Bullions                          |
+| 8732       | 0x80002214                    | BLN     | Bullions                          |
 | 8866       | 0x800022a2                    | GGX     | Golden Gate                       |
 | 8886       | 0x800022b6                    | GGXT    | Golden Gate Sydney                |
 | 8888       | 0x800022b8                    | SBTC    | Super Bitcoin                     |

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1226,6 +1226,7 @@ All these constants are used as hardened derivation.
 | 8444       | 0x800020fc                    | XCH     | Chia                              |
 | 8520       | 0x80002148                    | ---     | reserved                          |
 | 8680       | 0x800021e8                    | PLMNT   | Planetmint                        |
+| 8732       | 0x80008732                    | BLN     | Bullions                          |
 | 8866       | 0x800022a2                    | GGX     | Golden Gate                       |
 | 8886       | 0x800022b6                    | GGXT    | Golden Gate Sydney                |
 | 8888       | 0x800022b8                    | SBTC    | Super Bitcoin                     |


### PR DESCRIPTION
This commit adds the Bullions Smart Chain to the SLIP-44 registry with the following details:

- Chain Name: Bullions Smart Chain
- Chain ID: 8732
- SLIP-44 Code: 0x8000221C
- Native Currency: Bullions (BLN)
- RPC URL: https://rpc.bullionsx.org/
- Explorer: [Bullionscan](https://bullionscan.io/)
- Info URL: [BullionsX](https://www.bullionsx.io/)