### PR TITLE
slip-0044: add RED to registered coint types

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1177,6 +1177,7 @@ All these constants are used as hardened derivation.
 | 3564       | 0x80000dec                    | DST     | DeStream                          |
 | 3601       | 0x80000e11                    | CY      | Cybits                            |
 | 3757       | 0x80000ead                    | MPC     | Partisia Blockchain               |
+| 3840       | 0x80000f00                    | RED     | ReDeFi RED                        |
 | 4040       | 0x80000fc8                    | FC8     | FCH Network                       |
 | 4096       | 0x80001000                    | YEE     | YeeCo                             |
 | 4218       | 0x8000107a                    | IOTA    | IOTA                              |


### PR DESCRIPTION
ReDeFi Network website: https://redefi.world
ReDeFi layer2 network, that uses RED: https://layer2.redefi.world