### PR TITLE
Add coin type for ImFACT to slip-0044.md

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -843,7 +843,7 @@ All these constants are used as hardened derivation.
 | 812        | 0x8000032c                    |         |
 | 813        | 0x8000032d                    | MEER    | Qitmeer                           |
 | 814        | 0x8000032e                    |         |
-| 815        | 0x8000032f                    |         |
+| 815        | 0x8000032f                    | FACT    | ImFACT                            |
 | 816        | 0x80000330                    | FSC     | FSC                               |
 | 817        | 0x80000331                    |         |
 | 818        | 0x80000332                    | VET     | VeChain Token                     |


### PR DESCRIPTION
- Registered ImFACT cointype
- Updated relevant documentation

[https://www.imfact.im/](https://www.imfact.im/)