### PR TITLE
Add Go port to other implementations section of slip-0039.md

### DIFF
--- a/slip-0039.md
+++ b/slip-0039.md
@@ -323,6 +323,10 @@ Dart:
 
 * <https://github.com/ilap/slip39-dart>
 
+Go:
+
+* <https://github.com/gavincarr/go-slip39>
+
 JavaScript:
 
 * <https://github.com/ilap/slip39-js>


### PR DESCRIPTION
I ported the slip-0039 python reference implementation to Go recently, and thought you might like a link to the port in the spec.

Feedback on the library is welcome. Tests are reasonably comprehensive, and everything looks good so far.

