### PR TITLE
Add Frequency to SLIP-0044

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1142,6 +1142,7 @@ All these constants are used as hardened derivation.
 | 2049       | 0x80000801                    | TRUE    | TrueChain                         |
 | 2050       | 0x80000802                    | MOVO    | Movo Smart Chain                  |
 | 2086       | 0x80000826                    | KILT    | KILT Spiritnet                    |
+| 2091       | 0x8000082b                    | FRQCY   | Frequency                         |
 | 2109       | 0x8000083d                    | SAMA    | Exosama Network                   |
 | 2112       | 0x80000840                    | IoTE    | IoTE                              |
 | 2125       | 0x8000084d                    | BAY     | BitBay                            |


### PR DESCRIPTION
Adding Frequency to the list of chain types for general use and in preparation for using SLIP-0044 in a data structure for connected addresses.

- Frequency: https://www.frequency.xyz/
- Frequency GitHub: https://github.com/frequency-chain/
- Related: https://github.com/frequency-chain/schemas/pull/1