### PR TITLE
Add Lanify to SLIP-0044

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1162,6 +1162,7 @@ All these constants are used as hardened derivation.
 | 2570       | 0x80000a0a                    | AOA     | Aurora                            |
 | 2686       | 0x80000a7e                    | AIPG    | AIPowerGrid                       |
 | 2718       | 0x80000a9e                    | NAS     | Nebulas                           |
+| 2809       | 0x80000af9                    | LAN     | Lanify                            |
 | 2894       | 0x80000b4e                    | REOSC   | REOSC Ecosystem                   |
 | 2941       | 0x80000b7d                    | BND     | Blocknode                         |
 | 3000       | 0x80000bb8                    | SM      | Stealth Message                   |


### PR DESCRIPTION
Adding Lanify to the list of chain types and preparing to use SLIP-0044 in the data structure for connected addresses.