### PR TITLE
Add curve25519 to SLIP-0010 and improve documentation

### DIFF
--- a/slip-0010.md
+++ b/slip-0010.md
@@ -14,7 +14,7 @@ Created: 2016-04-26
 
 SLIP-0010 describes a generalized derivation scheme for private and public key
 pairs in hierarchical deterministic wallets for the curves secp256k1,
-NIST P-256 and ed25519.
+NIST P-256, ed25519 and curve25519.
 
 ## Motivation
 
@@ -45,11 +45,23 @@ other difference is the curve domain parameters.  In the algorithm below
 we denote the group order of the elliptic curve by n. point(k) is the
 scalar multiplication of the curve generator by the scalar k.
 The operation (+) of two elements on the curve is the group point
-addition.  For the ed25519 curve the private keys are no longer
+addition.  For ed25519 and curve25519 the private keys are no longer
 multipliers for the group generator; instead the hash of the private
-key is the multiplier.  For this reason, our scheme for ed25519 does
+key is the multiplier.  For this reason, our scheme for ed25519 and curve25519 does
 not support public key derivation and uses the produced hashes directly
 as private keys.
+
+For ed25519 public keys we define ser<sub>P</sub>(P): serializes the elliptic
+curve point P = (x,y) on a twisted Edwards curve as a byte sequence:
+0x00 || ENC(x, y), where ENC is defined in [RFC 8032](https://datatracker.ietf.org/doc/html/rfc8032).
+
+For curve25519 public keys we define ser<sub>P</sub>(P): serializes the elliptic
+curve point P = (u,v) on a Montgomery curve as a byte sequence:
+0x00 || encodeUCoordinate(u, 255), where encodeUCoordinate is defined in [RFC 7748](https://datatracker.ietf.org/doc/html/rfc7748).
+
+For ed25519 and curve25519 private keys we define ser<sub>256</sub>(p) = p and
+parse<sub>256</sub>(p) = p, since private keys for these two curves are not
+integers but byte sequences.
 
 To avoid invalid master keys, the algorithm is retried with the
 intermediate hash as new seed if the key is invalid.
@@ -63,7 +75,7 @@ optional passphrase.
 1. Calculate I = HMAC-SHA512(Key = Curve, Data = S)
 2. Split I into two 32-byte sequences, I<sub>L</sub> and I<sub>R</sub>.
 3. Use parse<sub>256</sub>(I<sub>L</sub>) as master secret key, and I<sub>R</sub> as master chain code.
-4. If curve is not ed25519 and I<sub>L</sub> is 0 or ≥ n (invalid key):
+4. If curve is not ed25519 or curve25519 and I<sub>L</sub> is 0 or ≥ n (invalid key):
     * Set S := I and restart at step 1.
 
 The supported curves are
@@ -71,17 +83,18 @@ The supported curves are
 * Curve = "Bitcoin seed" for the secp256k1 curve (this is compatible with BIP-0032).
 * Curve = "Nist256p1 seed" for the NIST P-256 curve.
 * Curve = "ed25519 seed" for the ed25519 curve.
+* Curve = "curve25519 seed" for curve25519.
 
-For ed25519, the last step always succeeds since every 256-bit number
-(even 0) is a valid private key.
+For ed25519 and curve25519, the last step always succeeds since every
+32-byte sequence (even all zero) is a valid private key.
 
 ### Child key derivation (CKD) functions
 
 Private and public key derivation for NIST P-256 is identical to the
 generation for secp256k1 but uses the domain parameters of that curve.
 We change BIP-32 to not fail if the resulting key is not valid but
-retry hashing until a valid key is found.  For ed25519 only hardened
-key generation from Private parent key to private child key is supported.
+retry hashing until a valid key is found.  For ed25519 and curve25519 only hardened
+key generation from private parent key to private child key is supported.
 
 Given a parent extended key and an index i, it is possible to compute
 the corresponding child extended key. The algorithm to do so depends
@@ -98,11 +111,11 @@ The function CKDpriv((k<sub>par</sub>, c<sub>par</sub>), i) &rarr; (k<sub>i</sub
 1. Check whether i ≥ 2<sup>31</sup> (whether the child is a hardened key).
     * If so (hardened child): let I = HMAC-SHA512(Key = c<sub>par</sub>, Data = 0x00 || ser<sub>256</sub>(k<sub>par</sub>) || ser<sub>32</sub>(i)). (Note: The 0x00 pads the private key to make it 33 bytes long.)
     * If not (normal child):
-        * If curve is ed25519: return failure.
+        * If curve is ed25519 or curve25519: return failure.
         * let I = HMAC-SHA512(Key = c<sub>par</sub>, Data = ser<sub>P</sub>(point(k<sub>par</sub>)) || ser<sub>32</sub>(i)).
 2. Split I into two 32-byte sequences, I<sub>L</sub> and I<sub>R</sub>.
 3. The returned chain code c<sub>i</sub> is I<sub>R</sub>.
-4. If curve is ed25519: The returned child key k<sub>i</sub> is parse<sub>256</sub>(I<sub>L</sub>).
+4. If curve is ed25519 or curve25519: The returned child key k<sub>i</sub> is I<sub>L</sub>.
 5. If parse<sub>256</sub>(I<sub>L</sub>) ≥ n or parse<sub>256</sub>(I<sub>L</sub>) + k<sub>par</sub> (mod n) = 0 (resulting key is invalid):
     * let I = HMAC-SHA512(Key = c<sub>par</sub>, Data = 0x01 || I<sub>R</sub> || ser<sub>32</sub>(i) and restart at step 2.
 6. Otherwise: The returned child key k<sub>i</sub> is parse<sub>256</sub>(I<sub>L</sub>) + k<sub>par</sub> (mod n).
@@ -111,7 +124,7 @@ The HMAC-SHA512 function is specified in [RFC 4231](http://tools.ietf.org/html/r
 
 #### Public parent key &rarr; public child key
 
-This function always fails for ed25519 since normal derivation is not supported.
+This function always fails for ed25519 and curve25519 since normal derivation is not supported.
 
 The function CKDpub((K<sub>par</sub>, c<sub>par</sub>), i) &rarr; (K<sub>i</sub>, c<sub>i</sub>) computes a child extended public key from the parent extended public key. It is only defined for non-hardened child keys.
 
@@ -254,6 +267,41 @@ Seed (hex): 000102030405060708090a0b0c0d0e0f
   * private: 8f94d394a8e8fd6b1bc2f3f49f5c47e385281d5c17e65324b0f62483e37e8793
   * public: 003c24da049451555d51a7014a37337aa4e12d41e485abccfa46b47dfb2af54b7a
 
+### Test vector 1 for curve25519
+
+Seed (hex): 000102030405060708090a0b0c0d0e0f
+
+* Chain m
+  * fingerprint: 00000000
+  * chain code: 77997ca3588a1a34f3589279ea2962247abfe5277d52770a44c706378c710768
+  * private: d70a59c2e68b836cc4bbe8bcae425169b9e2384f3905091e3d60b890e90cd92c
+  * public: 005c7289dc9f7f3ea1c8c2de7323b9fb0781f69c9ecd6de4f095ac89a02dc80577
+* Chain m/0<sub>H</sub>
+  * fingerprint: 6f5a9c0d
+  * chain code: 349a3973aad771c628bf1f1b4d5e071f18eff2e492e4aa7972a7e43895d6597f
+  * private: cd7630d7513cbe80515f7317cdb9a47ad4a56b63c3f1dc29583ab8d4cc25a9b2
+  * public: 00cb8be6b256ce509008b43ae0dccd69960ad4f7ff2e2868c1fbc9e19ec3ad544b
+* Chain m/0<sub>H</sub>/1<sub>H</sub>
+  * fingerprint: fde474d7
+  * chain code: 2ee5ba14faf2fe9d7ab532451c2be3a0a5375c5e8c44fb31d9ad7edc25cda000
+  * private: a95f97cfc1a61dd833b882c89d36a78a030ea6b2fbe3ae2a70e4f1fc9008d6b1
+  * public: 00e9506455dce2526df42e5e4eb5585eaef712e5f9c6a28bf9fb175d96595ea872
+* Chain m/0<sub>H</sub>/1<sub>H</sub>/2<sub>H</sub>
+  * fingerprint: 6569dde7
+  * chain code: e1897d5a96459ce2a3d294cb2a6a59050ee61255818c50e03ac4263ef17af084
+  * private: 3d6cce04a9175929da907a90b02176077b9ae050dcef9b959fed978bb2200cdc
+  * public: 0018f008fcbc6d1cd8b4fe7a9eba00f6570a9da02a9b0005028cb2731b12ee4118
+* Chain m/0<sub>H</sub>/1<sub>H</sub>/2<sub>H</sub>/2<sub>H</sub>
+  * fingerprint: 1b7cce71
+  * chain code: 1cccc84e2737cfe81b51fbe4c97bbdb000f6a76eddffb9ed03108fbff3ff7e4f
+  * private: 7ae7437efe0a3018999e6f00d72e810ebc50578dbf6728bfa1c7fe73501081a7
+  * public: 00512e288a8ef4d869620dc4b06bb06ad2524b350dee5a39fcfeb708dbac65c25c
+* Chain m/0<sub>H</sub>/1<sub>H</sub>/2<sub>H</sub>/2<sub>H</sub>/1000000000<sub>H</sub>
+  * fingerprint: de5dcb65
+  * chain code: 8ccf15d55b1dda246b0c1bf3e979a471a82524c1bd0c1eaecccf00dde72168bb
+  * private: 7a59954d387abde3bc703f531f67d659ec2b8a12597ae82824547d7e27991e26
+  * public: 00a077fcf5af53d210257d44a86eb2031233ac7237da220434ac01a0bebccc1919
+
 ### Test vector 2 for secp256k1
 
 Seed (hex): fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542
@@ -359,6 +407,41 @@ Seed (hex): fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c
   * private: 551d333177df541ad876a60ea71f00447931c0a9da16f227c11ea080d7391b8d
   * public: 0047150c75db263559a70d5778bf36abbab30fb061ad69f69ece61a72b0cfa4fc0
 
+### Test vector 2 for curve25519
+
+Seed (hex): fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542
+
+* Chain m
+  * fingerprint: 00000000
+  * chain code: b62c0c81a80a0ee16b977abb3677eb47549d0eef090f7a6c2b2010e739875e34
+  * private: 088491f5b4dfafbe956de471f3db10e02d784bc76050ee3b7c3f11b9706d3730
+  * public: 0060cc3b40567729af08757e1efe62536dc864a57ec582f98b96f484201a260c7a
+* Chain m/0<sub>H</sub>
+  * fingerprint: 75edaf13
+  * chain code: 341f386e571229e8adc52b82e824532817a31a35ba49ae334424e7228d020eed
+  * private: 8e73218a1ba5c7b95e94b6e7cf7b37fb6240fb3b2ecd801402a4439da7067ee2
+  * public: 007992b3f270ef15f266785fffb73246ad7f40d1fe8679b737fed0970d92cc5f39
+* Chain m/0<sub>H</sub>/2147483647<sub>H</sub>
+  * fingerprint: 5b26da66
+  * chain code: 942cbec088b4ae92e8db9336025e9185fec0985a3da89d7a408bc2a4e18a8134
+  * private: 29262b215c961bae20274588b33955c36f265c1f626df9feebb51034ce63c19d
+  * public: 002372feac417c38b833e1aba75f2420278122d698605b995cafc2fed7bb453d41
+* Chain m/0<sub>H</sub>/2147483647<sub>H</sub>/1<sub>H</sub>
+  * fingerprint: f701c832
+  * chain code: fe02397ae2ca71efe455f470fb23928baf026360a9e9090e21958f6fba9efc30
+  * private: a4d2474bd98c5e9ff416f536697b89949627d6d2c384b81a86d29f1136f4c2d1
+  * public: 00eca4fd0458d3f729b6218eda871b350fa8870a744caf6d30cd84dad2b9dd9c2d
+* Chain m/0<sub>H</sub>/2147483647<sub>H</sub>/1<sub>H</sub>/2147483646<sub>H</sub>
+  * fingerprint: 6063347b
+  * chain code: b3b49d550e732ee629f4aeb4bf7213c3ae0f239fd10add513253cddbb8efb868
+  * private: d3500d9b30529c51d92497eded1d68d29f60c630c45c61a481c185e574c6e5cf
+  * public: 00edaa3d381a2b02f40a80d69b2ce7ba7c3c4a9421744808857cd48c50d29b5868
+* Chain m/0<sub>H</sub>/2147483647<sub>H</sub>/1<sub>H</sub>/2147483646<sub>H</sub>/2<sub>H</sub>
+  * fingerprint: 86bf4fed
+  * chain code: f6ded904046e9758b9388dbf95ea5db837ab98b03b00e4db7009a8e3ac077685
+  * private: e20fecd59312b63b37eee27714465aae1caa1c87840abd0d685ea88b3d598fdf
+  * public: 00aa705de68066e9534a238af35ea77c48016462a8aff358d22eaa6c7d5b034354
+
 ### Test derivation retry for nist256p1
 
 Seed (hex): 000102030405060708090a0b0c0d0e0f
@@ -401,3 +484,5 @@ Seed (hex): a7305bc8df8d0951f0cb224c0e95d7707cbdf2c6ce7e8d481fec69c7ff5e9446
 * [BIP-0032: Hierarchical Deterministic Wallets](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki)
 * [BIP-0039: Mnemonic code for generating deterministic keys](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki)
 * [SLIP-0039: Shamir's Secret-Sharing for Mnemonic Codes](https://github.com/satoshilabs/slips/blob/master/slip-0039.md)
+* [RFC 8032: Edwards-Curve Digital Signature Algorithm (EdDSA)](https://datatracker.ietf.org/doc/html/rfc8032)
+* [RFC 7748: Elliptic Curves for Security](https://datatracker.ietf.org/doc/html/rfc7748)

--- a/slip-0010.md
+++ b/slip-0010.md
@@ -12,8 +12,9 @@ Created: 2016-04-26
 
 ## Abstract
 
-SLIP-0010 describes how to derive private and public key pairs for curve
-types different from secp256k1.
+SLIP-0010 describes a generalized derivation scheme for private and public key
+pairs in hierarchical deterministic wallets for the curves secp256k1,
+NIST P-256 and ed25519.
 
 ## Motivation
 
@@ -31,7 +32,7 @@ mnemonic or from a set of [SLIP-0039](https://github.com/satoshilabs/slips/blob/
 mnemonic shares and optionally a passphrase.  Each of these standards specifies
 how to compute a seed from the mnemonic(s) and passphrase.  From this
 seed Trezor can create several master keys, one for each curve.  It uses a
-process similar and compatible with BIP-0032.  For other curves it uses a
+process similar and practically compatible with BIP-0032.  For other curves it uses a
 different salt than BIP-0032.  This avoids using the same private key
 for different elliptic curves with different orders.
 
@@ -122,6 +123,29 @@ The function CKDpub((K<sub>par</sub>, c<sub>par</sub>), i) &rarr; (K<sub>i</sub>
 4. The returned chain code c<sub>i</sub> is I<sub>R</sub>.
 5. If parse<sub>256</sub>(I<sub>L</sub>) ≥ n or K<sub>i</sub> is the point at infinity (the resulting key is invalid):
     * let I = HMAC-SHA512(Key = c<sub>par</sub>, Data = 0x01 || I<sub>R</sub> || ser<sub>32</sub>(i)) and restart at step 2.
+
+## Compatibility with BIP-0032
+
+Master key generation in BIP-0032 may result in an invalid key, in which case
+the wallet keys are undefined. Similarly child key derivation may result in an
+invalid key, in which case the child key for the given index is undefined and
+one should proceed with the next index value. For the secp256k1 curve the
+probability of this happening is lower than 2<sup>&minus;127</sup>,
+i.e. practically impossible. For the NIST P-256 curve, on the other hand, the
+probability is 2<sup>&minus;32</sup>, i.e. unlikely but possible. The present
+specification extends the BIP-0032 definition of child key derivation so that
+the keys for all indices are well defined. The reason for extending the
+definition is to avoid problems when dealing with the NIST P-256 curve. However,
+the extended definition also applies to the secp256k1 curve.
+
+For the secp256k1 curve the SLIP-0010 derivation scheme is identical to BIP-0032
+with near certainty (probability greater than 1&minus;2<sup>&minus;127</sup> per
+derivation operation). Theoretically, if a seed is used in a SLIP-0010 wallet to
+receive assets and the seed is ported to a BIP-0032 wallet, then there is an
+infinitesimal chance that some assets will not be discovered by the BIP-0032
+wallet. Conversely, if a seed is used in a BIP-0032 wallet to receive assets and
+the seed is ported to a SLIP-0010 wallet, then all assets will be discovered by
+the SLIP-0010 wallet.
 
 ## Test vectors
 

--- a/slip-0010/testvectors.py
+++ b/slip-0010/testvectors.py
@@ -1,45 +1,30 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
-import binascii
 import hashlib
 import hmac
-import struct
-import ecdsa
-import ed25519
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.asymmetric import ec
 from base58 import b58encode_check
 
+SECP256K1_ORDER = int("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141", 16)
+SECP256R1_ORDER = int("FFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551", 16)
 privdev = 0x80000000
 
-def int_to_string(x, pad):
-    result = ['\x00'] * pad
-    while x > 0:
-        pad -= 1
-        ordinal = x & 0xFF
-        result[pad] = (chr(ordinal))
-        x >>= 8
-    return ''.join(result)
-
-def string_to_int(s):
-    result = 0
-    for c in s:
-        if not isinstance(c, int):
-            c = ord(c)
-        result = (result << 8) + c
-    return result
-
 # mode 0 - compatible with BIP32 private derivation
-def seed2hdnode(seed, modifier, curve):
+def seed2hdnode(seed, curve, modifier, curve_order):
     k = seed
     while True:
         h = hmac.new(modifier, seed, hashlib.sha512).digest()
         key, chaincode = h[:32], h[32:]
-        a = string_to_int(key)
-        if (curve == 'ed25519'):
+        a = int.from_bytes(key, 'big')
+        if (curve in ('ed25519', 'curve25519')):
             break
-        if (a < curve.order and a != 0):
+        if (a < curve_order and a != 0):
             break
         seed = h
-        #print 'RETRY seed: ' + binascii.hexlify(seed)
+        #print('RETRY seed: ' + seed.hex())
     return (key, chaincode)
 
 def fingerprint(publickey):
@@ -47,105 +32,115 @@ def fingerprint(publickey):
     return h[:4]
 
 def b58xprv(parent_fingerprint, private_key, chain, depth, childnr):
-    raw = ('\x04\x88\xad\xe4' +
-              chr(depth) + parent_fingerprint + int_to_string(childnr, 4) +
-              chain + '\x00' + private_key)
-    return b58encode_check(raw)
+    raw = (b'\x04\x88\xad\xe4' +
+              bytes([depth]) + parent_fingerprint + childnr.to_bytes(4, 'big') +
+              chain + b'\x00' + private_key)
+    return b58encode_check(raw).decode()
 
 def b58xpub(parent_fingerprint, public_key, chain, depth, childnr):
-    raw = ('\x04\x88\xb2\x1e' +
-              chr(depth) + parent_fingerprint + int_to_string(childnr, 4) +
+    raw = (b'\x04\x88\xb2\x1e' +
+              bytes([depth]) + parent_fingerprint + childnr.to_bytes(4, 'big') +
               chain + public_key)
-    return b58encode_check(raw)
+    return b58encode_check(raw).decode()
 
 def publickey(private_key, curve):
     if curve == 'ed25519':
-        sk = ed25519.SigningKey(private_key)
-        return '\x00' + sk.get_verifying_key().to_bytes()
+        sk = Ed25519PrivateKey.from_private_bytes(private_key)
+        key_encoding = serialization.Encoding.Raw
+        key_format = serialization.PublicFormat.Raw
+        prefix = b'\x00'
+    elif curve == 'curve25519':
+        sk = X25519PrivateKey.from_private_bytes(private_key)
+        key_encoding = serialization.Encoding.Raw
+        key_format = serialization.PublicFormat.Raw
+        prefix = b'\x00'
     else:
-        Q = string_to_int(private_key) * curve.generator
-        xstr = int_to_string(Q.x(), 32)
-        parity = Q.y() & 1
-        return chr(2 + parity) + xstr
+        sk = ec.derive_private_key(int.from_bytes(private_key, 'big'), curve)
+        key_encoding = serialization.Encoding.X962
+        key_format = serialization.PublicFormat.CompressedPoint
+        prefix = b''
+    return prefix + sk.public_key().public_bytes(key_encoding, key_format)
 
-def derive(parent_key, parent_chaincode, i, curve):
+def derive(parent_key, parent_chaincode, i, curve, curve_order):
     assert len(parent_key) == 32
     assert len(parent_chaincode) == 32
     k = parent_chaincode
     if ((i & privdev) != 0):
-        key = '\x00' + parent_key
+        key = b'\x00' + parent_key
     else:
         key = publickey(parent_key, curve)
-    d = key + struct.pack('>L', i)
+    d = key + i.to_bytes(4, 'big')
     while True:
         h = hmac.new(k, d, hashlib.sha512).digest()
         key, chaincode = h[:32], h[32:]
-        if curve == 'ed25519':
+        if curve in ('ed25519', 'curve25519'):
             break
-        #print 'I: ' + binascii.hexlify(h)
-        a = string_to_int(key)
-        key = (a + string_to_int(parent_key)) % curve.order
-        if (a < curve.order and key != 0):
-            key = int_to_string(key, 32)
+        #print('I: ' + h.hex())
+        a = int.from_bytes(key, 'big')
+        key = (a + int.from_bytes(parent_key, 'big')) % curve_order
+        if (a < curve_order and key != 0):
+            key = key.to_bytes(32, 'big')
             break
-        d = '\x01' + h[32:] + struct.pack('>L', i)
-        #print 'a failed: ' + binascii.hexlify(h[:32])
-        #print 'RETRY: ' + binascii.hexlify(d)
+        d = b'\x01' + h[32:] + i.to_bytes(4, 'big')
+        #print('a failed: ' + h[:32].hex())
+        #print('RETRY: ' + d.hex())
                         
     return (key, chaincode)
 
 def get_curve_info(curvename):
     if curvename == 'secp256k1':
-        return (ecdsa.curves.SECP256k1, 'Bitcoin seed') 
+        return (ec.SECP256K1(), b'Bitcoin seed', SECP256K1_ORDER)
     if curvename == 'nist256p1':
-        return (ecdsa.curves.NIST256p, 'Nist256p1 seed') 
+        return (ec.SECP256R1(), b'Nist256p1 seed', SECP256R1_ORDER)
     if curvename == 'ed25519':
-        return ('ed25519', 'ed25519 seed')
+        return ('ed25519', b'ed25519 seed', None)
+    if curvename == 'curve25519':
+        return ('curve25519', b'curve25519 seed', None)
     raise BaseException('unsupported curve: '+curvename)
 
 def show_testvector(name, curvename, seedhex, derivationpath):
-    curve, seedmodifier = get_curve_info(curvename)
-    master_seed = binascii.unhexlify(seedhex)
-    k,c = seed2hdnode(master_seed, seedmodifier, curve)
+    curve, seedmodifier, curve_order = get_curve_info(curvename)
+    master_seed = bytes.fromhex(seedhex)
+    k,c = seed2hdnode(master_seed, curve, seedmodifier, curve_order)
     p = publickey(k, curve)
-    fpr = '\x00\x00\x00\x00'
+    fpr = b'\x00\x00\x00\x00'
     path = 'm'
-    print "### "+name+" for "+curvename
-    print ''
-    print "Seed (hex): " + seedhex
-    print ''
-    print '* Chain ' + path
-    print '  * fingerprint: ' + binascii.hexlify(fpr)
-    print '  * chain code: ' + binascii.hexlify(c)
-    print '  * private: ' + binascii.hexlify(k)
-    print '  * public: ' + binascii.hexlify(p)
+    print("### "+name+" for "+curvename)
+    print()
+    print("Seed (hex): " + seedhex)
+    print()
+    print('* Chain ' + path)
+    print('  * fingerprint: ' + fpr.hex())
+    print('  * chain code: ' + c.hex())
+    print('  * private: ' + k.hex())
+    print('  * public: ' + p.hex())
     depth = 0
     for i in derivationpath:
-        if curve == 'ed25519':
-            # no public derivation for ed25519
+        if curve in ('ed25519', 'curve25519'):
+            # no public derivation for ed25519 and curve25519
             i = i | privdev
         fpr = fingerprint(p)
         depth = depth + 1
         path = path + "/" + str(i & (privdev-1))
         if ((i & privdev) != 0):
             path = path + "<sub>H</sub>"
-        k,c = derive(k, c, i, curve)
+        k,c = derive(k, c, i, curve, curve_order)
         p = publickey(k, curve) 
-        print '* Chain ' + path
-        print '  * fingerprint: ' + binascii.hexlify(fpr)
-        print '  * chain code: ' + binascii.hexlify(c)
-        print '  * private: ' + binascii.hexlify(k)
-        print '  * public: ' + binascii.hexlify(p)
-        #print b58xprv(fpr, kc, cc, depth, i)
-        #print b58xpub(fpr, pc, cc, depth, i)
-    print
+        print('* Chain ' + path)
+        print('  * fingerprint: ' + fpr.hex())
+        print('  * chain code: ' + c.hex())
+        print('  * private: ' + k.hex())
+        print('  * public: ' + p.hex())
+        #print(b58xprv(fpr, k, c, depth, i))
+        #print(b58xpub(fpr, p, c, depth, i))
+    print()
 
 def show_testvectors(name, curvenames, seedhex, derivationpath):
     for curvename in curvenames:
         show_testvector(name, curvename, seedhex, derivationpath)
 
 
-curvenames = ['secp256k1', 'nist256p1', 'ed25519'];
+curvenames = ['secp256k1', 'nist256p1', 'ed25519', 'curve25519'];
         
 show_testvectors("Test vector 1", curvenames,
                  '000102030405060708090a0b0c0d0e0f',


### PR DESCRIPTION
Resolves https://github.com/satoshilabs/slips/issues/1409 by clarifying that SLIP-0010 applies to secp256k1 and explaining compatibility with BIP-0032.

Resolves https://github.com/satoshilabs/slips/issues/1251 by clarifying the encoding of ed25519 public keys.

Adds curve25519 to the specification in accordance with how it is used in Trezor firmware for the implementation of [SLIP-0017](https://github.com/satoshilabs/slips/blob/master/slip-0017.md).