### PR TITLE
Add OverProtocol to SLIP-0044

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1298,6 +1298,7 @@ All these constants are used as hardened derivation.
 | 49262      | 0x8000c06e                    | EVE     | evan                              |
 | 49344      | 0x8000c0c0                    | STASH   | STASH                             |
 | 52752      | 0x8000ce10                    | CELO    | Celo                              |
+| 54176      | 0x8000d3a0                    | OVER    | OverProtocol                      |
 | 61616      | 0x8000f0b0                    | TH      | TianHe                            |
 | 65536      | 0x80010000                    | KETH    | Krypton World                     |
 | 69420      | 0x80010f2c                    | GRLC    | Garlicoin                         |


### PR DESCRIPTION
Adding OverProtocol to the list of chain types for general use and in preparation for using SLIP-0044 in a data structure for connected addresses.