### PR TITLE
Add Bech32 for Lorenzo

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -155,6 +155,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | Litecoin                 | `ltc`         | `tltc`   | `rltc`      |
 | Logos                    | `logos`       |          |             |
 | Loop                     | `loop`        |          |             |
+| Lorenzo                  | `lrz`         |          |             |
 | Loyal                    | `loyal`       |          |             |
 | Lum Network              | `lum`         |          |             |
 | LumenX                   | `lumen`       |          |             |


### PR DESCRIPTION
Register the human-readable parts for usage in Bech32 for [Lorenzo Chain](https://www.lorenzo-protocol.xyz/).