### PR TITLE
Add Sparrow Wallet to list of wallets that support SLIP39

### DIFF
--- a/slip-0039.md
+++ b/slip-0039.md
@@ -337,10 +337,11 @@ Rust:
 * <https://github.com/rust-bitcoin/rust-wallet/blob/master/src/sss.rs>
 * <https://github.com/Internet-of-People/slip39-rust>
 
-Python wallets with SLIP39 support:
+Wallets with SLIP39 support:
 
 * <https://github.com/unchained-capital/hermit>
 * <https://electrum.org/>
+* <https://sparrowwallet.com/>
 
 ## Design rationale
 


### PR DESCRIPTION
Sparrow wallet supports SLIP39 since version 2.0.0