### PR TITLE
chore: Adding MANTRA Chain

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -168,6 +168,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | LumenX                   | `lumen`       |          |             |
 | Lyncoin                  | `lc`          | `tlc`    | `lcrt`      |
 | Mande Network            | `mande`       |          |             |
+| MANTRA Chain             | `mantra`      |          |             |
 | Mars Protocol            | `mars`        |          |             |
 | Maya Protocol            | `maya`        | `smaya`  |             |
 | Medas Digital            | `medas`       |          |             |


### PR DESCRIPTION
# Brief
Add MANTRA Chain network/coin moniker to SLIP-0173

**Chain Name:** MANTRA Chain
**Moniker _(mainnet)_:** `mantra`

- https://mantrachain.io
- https://docs.mantrachain.io