### PR TITLE
Update slip-0044.md

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -736,7 +736,7 @@ All these constants are used as hardened derivation.
 | 705        | 0x800002c1                    | PEG     | Pegasus Token                     |
 | 706        | 0x800002c2                    | LKG     | Lionking                          |
 | 707        | 0x800002c3                    | MCOIN   | Moneta Coin                       |
-| 708        | 0x800002c4                    |         |
+| 708        | 0x800002c4                    | ---     | reserved                          |
 | 709        | 0x800002c5                    | AVAIL   | Avail                             |
 | 710        | 0x800002c6                    | FURY    | Highbury                          |
 | 711        | 0x800002c7                    | CHC     | Chaincoin                         |


### PR DESCRIPTION
Number:  SLIP-0044
Title:   Registered coin types for BIP-0044
Type:    Standard
Status:  Active
Authors: James Huang <1109007763hzy@gmail.com>
Created: 2024-10-27