### PR TITLE
Add Convex Coin Type (CVM)

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -892,7 +892,7 @@ All these constants are used as hardened derivation.
 | 861        | 0x8000035d                    |         |
 | 862        | 0x8000035e                    |         |
 | 863        | 0x8000035f                    |         |
-| 864        | 0x80000360                    |         |
+| 864        | 0x80000360                    | CVM     | Convex                            |
 | 865        | 0x80000361                    |         |
 | 866        | 0x80000362                    | MOB     | MobileCoin                        |
 | 867        | 0x80000363                    |         |


### PR DESCRIPTION
This PR adds the Convex Coin as a new coin type (CVM)

We have multiple wallets implemented for Convex, including Convex Desktop (see https://docs.convex.world/docs/products/convex-desktop ) which uses SLIP-10 for key generation, hence it would be good to have a registered coin type in SLIP-44