### PR TITLE
Add Osmosis network with ID 1017 to SLIP-44

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1045,6 +1045,7 @@ All these constants are used as hardened derivation.
 | 1014       | 0x800003f6                    | JOY     | Joystream                         |
 | 1015       | 0x800003f7                    | ZCX     | ZEN Exchange Token                |
 | 1016       | 0x800003f8                    | ---     | reserved                          |
+| 1017       | 0x800003f9                    | OSMO    | Osmosis                           |
 | 1020       | 0x800003fc                    | EVC     | Evrice                            |
 | 1022       | 0x800003fe                    | XRD     | Radix DLT                         |
 | 1023       | 0x800003ff                    | ONE     | HARMONY-ONE (Legacy)              |


### PR DESCRIPTION
This PR adds the Osmosis network to SLIP-44 with the following details:

- **Coin type**: 1017
- **Path component**: 0x800003F9
- **Symbol**: OSMO
- **Coin**: Osmosis
- **Website**: [https://osmosis.zone/](https://osmosis.zone/)

**Rationale:**
Osmosis is a widely-used decentralized exchange (DEX) and blockchain built on the Cosmos SDK, with its native token OSMO. The network supports liquidity provisioning, staking, and governance. Adding Osmosis to SLIP-44 ensures compatibility with BIP-44 wallets and simplifies the derivation of Osmosis-specific addresses.

**References:**
- Official website: [https://osmosis.zone/](https://osmosis.zone/)
- Block explorer: [https://mintscan.io/osmosis](https://mintscan.io/osmosis)

Please review and let me know if further changes are needed.
