### PR TITLE
Add Osmosis network with ID 10000118 to SLIP-44 instead of 1017

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1045,7 +1045,6 @@ All these constants are used as hardened derivation.
 | 1014       | 0x800003f6                    | JOY     | Joystream                         |
 | 1015       | 0x800003f7                    | ZCX     | ZEN Exchange Token                |
 | 1016       | 0x800003f8                    | ---     | reserved                          |
-| 1017       | 0x800003f9                    | OSMO    | Osmosis                           |
 | 1020       | 0x800003fc                    | EVC     | Evrice                            |
 | 1022       | 0x800003fe                    | XRD     | Radix DLT                         |
 | 1023       | 0x800003ff                    | ONE     | HARMONY-ONE (Legacy)              |
@@ -1366,6 +1365,7 @@ All these constants are used as hardened derivation.
 | 7825266    | 0x80776772                    | WGR     | WGR                               |
 | 7825267    | 0x80776773                    | OBSR    | OBServer                          |
 | 8163271    | 0x807c8fc7                    | AFS     | ANFS                              |
+| 10000118   | 0x805d30b6                    | OSMO    | Osmosis                           |
 | 15118976   | 0x80e6b280                    | XDS     | XDS                               |
 | 61717561   | 0x83adbc39                    | AQUA    | Aquachain                         |
 | 77777777   | 0x84a2cb71                    | AZT     | Aztecoin                          |


### PR DESCRIPTION
This PR updates the Osmosis network entry in SLIP-44 by changing its coin type from `1017` to `10000118`. The updated details are as follows:

- **Coin type**: 10000118
- **Path component**: 0x805D30B6
- **Symbol**: OSMO
- **Coin**: Osmosis
- **Website**: [https://osmosis.zone/](https://osmosis.zone/)

**Reason for Change:**
After further review, `10000118` was identified as the correct coin type for the Osmosis network. This change ensures alignment with other standards and avoids potential conflicts with existing coin types.

**References:**
- Official website: [https://osmosis.zone/](https://osmosis.zone/)
- Block explorer: [https://mintscan.io/osmosis](https://mintscan.io/osmosis)

Please let me know if there are any questions or further adjustments required.
