### PR TITLE
Updated KLAY to KAIA

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1237,7 +1237,7 @@ All these constants are used as hardened derivation.
 | 8080       | 0x80001f90                    |         | DSRV                              |
 | 8181       | 0x80001ff5                    | BOC     | BeOne Chain                       |
 | 8192       | 0x80002000                    | PAC     | pacprotocol                       |
-| 8217       | 0x80002019                    | KLAY    | KLAY                              |
+| 8217       | 0x80002019                    | KAIA    | KAIA                              |
 | 8339       | 0x80002093                    | BTQ     | BitcoinQuark                      |
 | 8444       | 0x800020fc                    | XCH     | Chia                              |
 | 8453       | 0x80002105                    |         | Base                              |


### PR DESCRIPTION
Updated the coin name from KLAY to KAIA as part of rebranding.

More details can be found here
https://www.binance.com/en/support/announcement/binance-will-support-the-kaia-klay-rebranding-to-kaia-kaia-f75f933759ee49d0af1dfbce7e32144c
https://docs.kaia.io/misc/kaia-transition/faq-chain-transition/#what-happened-to-klaytn-and-finschia-