### PR TITLE
Add OPCT Chain bech32 prefix

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -210,6 +210,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | OKP4                     | `okp4`        |          |             |
 | Omni                     | `o`           | `to`     | `ocrt`      |
 | OmniFlix                 | `omniflix`    |          |             |
+| OPCT Chain               | `opct`        |          |             |
 | Onomy                    | `onomy`       |          |             |
 | Oraichain                | `orai`        |          |             |
 | Osmosis                  | `osmo`        |          |             |


### PR DESCRIPTION
Add OPCT Chain bech32 prefix

OPCT Chain is the GRIT Protocol, established in 2020 by AI researchers and developers who recognized the need to maintain physical and mental well-being in an unpredictable and rapidly changing world.

Details:
- Chain ID: opct_1
- Website: https://www.opct.ai
- Status: Mainnet
- Prefix: opct