### PR TITLE
Add Alph Network to SLIP-0044 registry

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1272,7 +1272,7 @@ All these constants are used as hardened derivation.
 | 99999999   | 0x85f5e0ff                    | QKC     | QuarkChain                        |
 | 608589380  | 0xa4465644                    | FVDC    | ForumCoin                         |
 | 1179993420 | 0xc655454c                    |         | Fuel                              |
-
+| 8738       | 0x2222                        | ALPH    | Alph Network                      |
 Coin types will be added only if there is a wallet implementing BIP-0044 for desired coin.
 
 ## Libraries


### PR DESCRIPTION
This Pull Request adds support for Alph Network to the SLIP-0044 registry.

### Details:
- **Coin Name:** Alph Network  
- **Symbol:** ALPH  
- **Coin Type:** 8738  
- **Chain ID:** 0x2222 (Decimal: 8738)  
- **Mainnet RPC URL:** https://rpc.alph.network  
- **Explorer URL:** https://explorer.alph.network  

### Changes:
- Added the following entry to `slip-0044.md`:
  ```markdown
  | Coin type  | Path component (`coin_type'`) | Symbol  | Coin         |
  |------------|-------------------------------|---------|--------------|
  | 8738       | 8738'                        | ALPH    | Alph Network |
