### PR TITLE
Add Free AI Chain to SLIP-0044

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1390,6 +1390,7 @@ All these constants are used as hardened derivation.
 | 1179993431 | 0xc6554557                    | MTGBP   | MTGBP                             |
 | 1179993441 | 0xc6554561                    | QFS     | Qfs                               |
 | 1179993451 | 0xc655456b                    | RWA     | Asset Chain                       |
+| 1010101010 | 0xBC34EB12                    | FAIC    | Free AI Chain                     |
 
 Coin types will be added only if there is a wallet implementing BIP-0044 for desired coin.
 

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1390,7 +1390,7 @@ All these constants are used as hardened derivation.
 | 1179993431 | 0xc6554557                    | MTGBP   | MTGBP                             |
 | 1179993441 | 0xc6554561                    | QFS     | Qfs                               |
 | 1179993451 | 0xc655456b                    | RWA     | Asset Chain                       |
-| 1010101010 | 0xBC34EB12                    | FAIC    | Free AI Chain                     |
+| 1010101010 | 0xbc34eb12                    | FAIC    | Free AI Chain                     |
 
 Coin types will be added only if there is a wallet implementing BIP-0044 for desired coin.
 

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1385,12 +1385,12 @@ All these constants are used as hardened derivation.
 | 20230101   | 0x8134afd5                    | ROH     | Rooch                             |
 | 20240430   | 0x8134d82e                    | NLK     | NuLinkCoin                        |
 | 608589380  | 0xa4465644                    | FVDC    | ForumCoin                         |
+| 1010101010 | 0xbc34eb12                    | FAIC    | Free AI Chain                     |
 | 1179993420 | 0xc655454c                    |         | Fuel                              |
 | 1179993421 | 0xc655454d                    | TTNC    | TakeTitan                         |
 | 1179993431 | 0xc6554557                    | MTGBP   | MTGBP                             |
 | 1179993441 | 0xc6554561                    | QFS     | Qfs                               |
 | 1179993451 | 0xc655456b                    | RWA     | Asset Chain                       |
-| 1010101010 | 0xbc34eb12                    | FAIC    | Free AI Chain                     |
 
 Coin types will be added only if there is a wallet implementing BIP-0044 for desired coin.
 


### PR DESCRIPTION
This PR adds Free AI Chain (FAIC) with coin_type 1010101010/0xBC34EB12 to the SLIP-0044 registry.

| Coin type  | Path component (`coin_type'`) | Symbol  | Coin                              |
| ---------- | ----------------------------- | ------- | --------------------------------- |
| 1010101010 | 0xBC34EB12                    | FAIC    | Free AI Chain                     |