### PR TITLE
Add TrustNet to Slip-0044

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1003,7 +1003,7 @@ All these constants are used as hardened derivation.
 | 972        | 0x800003cc                    |         |
 | 973        | 0x800003cd                    |         |
 | 974        | 0x800003ce                    |         |
-| 975        | 0x800003cf                    |         |
+| 975        | 0x800003cf                    |         | TrustNet                          |
 | 976        | 0x800003d0                    |         |
 | 977        | 0x800003d1                    | TLOS    | Telos                             |
 | 978        | 0x800003d2                    |         |


### PR DESCRIPTION
I would like to reserve coin type index 975 for use with TrustNet. This is a blockchain used for decentralized identity, but in the future we intend on having our wallets support different crypto currencies as well, so a coin type is required to manage the user's various identities and crypto wallets.

You can see our identity offering [here](https://qikfox.com/digital-identity)
You can see our DID Method [here](https://github.com/qikfox/fox-did-method)
You can also see our PR for registration to the w3c as a DID method [here](https://github.com/w3c/did-extensions/pull/592?new_mergebox=false)

This coin type is currently in use in our wallet, but the repository is private for now. I am providing a code snippet for proof of its usage in a wallet.

```rust

    // Convert mnemonic to seed without a passphrase
    let seed = mnemonic.to_seed("");

    // Check seed length for generating keypair
    if seed.len() < ed25519_dalek::SECRET_KEY_LENGTH {
        error_result.error_message = "Seed is too short".to_string();
        return error_result;
    }

    // Create the HD path to be used for ed25519 primary key derivation, this needs
    // to be the BIP32 standard because slip-10 uses BIP32 paths
    let ed25519_hdpath = match hdpath::CustomHDPath::from_str("m/44'/975'/0'/0'/0'") {
        Ok(p) => p,
        Err(_e) => {
            error_result.error_message = format!("Failed to create HD path for ed25519");
            return error_result;
        }
    };

    // We need to convert the main hdpath to a BIP32Path for use with slip-10 crate
    let bip32path = match slipped10::path::BIP32Path::from_str(&ed25519_hdpath.to_string()) {
        Ok(p) => p,
        Err(e) => {
            error_result.error_message = format!("Failed to create BIP32 path: {}", e);
            return error_result;
        }
    };

    // Create the primary ed25519 keypair from the seed
    let ed25519_secret: slipped10::Key =
        match slipped10::derive_key_from_path(&seed, slipped10::Curve::Ed25519, &bip32path) {
            Ok(s) => s,
            Err(e) => {
                error_result.error_message =
                    format!("Failed to derive key from seed using BIP32 path: {}", e);
                return error_result;
            }
        };
```