### PR TITLE
Add Maniest Network to the slip-0173 registry

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -21,285 +21,286 @@ The BIP repository does not want to deal with assigning the values for various c
 
 These are the registered human-readable parts for usage in Bech32 encoding of witness programs.
 
-| Coin                     | Mainnet       | Testnet  | Regtest     |
-| ------------------------ | ------------- | -------- | ----------- |
-| 8ball                    | `8ball`       |          |             |
-| Aaron Network            | `aaron`       |          |             |
-| Acrechain                | `acre`        |          |             |
-| Agoric                   | `agoric`      |          |             |
-| AIOZ Network             | `aioz`        |          |             |
-| Akash                    | `akash`       |          |             |
-| Allora                   | `allo`        |          |             |
-| Andromeda                | `andr`        |          |             |
-| Alaya                    | `atp`         | `atx`    |             |
-| Althea                   | `althea`      |          |             |
-| Archway                  | `archway`     | `const`  |             |
-| Apc                      | `apc`         |          |             |
-| Arkhadian                | `arkh`        |          |             |
-| AssetMantle              | `mantle`      |          |             |
-| Athena                   | `ath`         | `atest`  |             |
-| AtomOne                  | `atone`       |          |             |
-| Aura Network             | `aura`        |          |             |
-| Axelar                   | `axelar`      |          |             |
-| Axone                    | `axone`       |          |             |
-| Babylon                  | `bbn`         |          |             |
-| BARE                     | `bare`        | `tbare`  | `bart`      |
-| Band Protocol            | `band`        |          |             |
-| BeeZee                   | `bze`         | `tbz`    |             |
-| Bellcoin                 | `bm`          | `bt`     | `br`        |
-| BeOne Chain              | `boc`         | `tboc`   |             |
-| Binance Chain            | `bnb`         |          |             |
-| BitCanna                 | `bcna`        |          |             |
-| BitBadges                | `bb`          |          |             |
-| Bitcoin                  | `bc`          | `tb`     | `bcrt`      |
-| Bitcoin Atom             | `bca`         | `tbca`   | `bcart`     |
-| Bitcoin Gold             | `btg`         | `tbtg`   |             |
-| Bitcoin Platinum         | `btp`         | `tbtp`   |             |
-| Bitcoin Post-Quantum     | `pq`          | `tq`     | `pqrt`      |
-| Bitcoin Private          | `btcp`        | `tbtcp`  | `regbtcp`   |
-| Bitcore                  | `btx`         | `tbtx`   |             |
-| BitSong                  | `bitsong`     |          |             |
-| BitZeny                  | `bz`          | `tz`     | `rz`        |
-| Blackcoin                | `blk`         | `tblk`   | `blrt`      |
-| Blacknet                 | `blacknet`    |          | `rblacknet` |
-| BlockX                   | `blockx`      |          |             |
-| BlueChip                 | `bcp`         |          |             |
-| Bluzelle                 | `bluzelle`    |          |             |
-| bostrom                  | `bostrom`     |          |             |
-| Bouachain                | `bouachain`   |          |             |
-| Canto                    | `canto`       |          |             |
-| Carbon                   | `swth`        |          |             |
-| Celestia                 | `celestia`    |          |             |
-| Cerberus                 | `cerberus`    |          |             |
-| Chain4Energy             | `c4e`         |          |             |
-| cheqd                    | `cheqd`       |          |             |
-| Chia                     | `xch`         | `txch`   |             |
-| Chihuahua                | `chihuahua`   |          |             |
-| Chimba                   | `chimba`      |          |             |
-| Chronic Chain            | `chronic`     |          |             |
-| Cifer                    | `cife`        | `cift`   |             |
-| City Coin                | `city`        | `tcity`  |             |
-| Cnho Stables             | `cnho`        |          |             |
-| Comdex                   | `comdex`      |          |             |
-| Commercio                | `did:com:`    |          |             |
-| Composable               | `centauri`    |          |             |
-| ConsciousDAO             | `cvn`         |          |             |
-| Coreum                   | `core`        |`testcore`|             |
-| Cosmos Hub               | `cosmos`      |          |             |
-| Coss Chain               | `coss`        | `tcoss`  |             |
-| CPUchain                 | `cpu`         | `tcpu`   | `rcpu`      |
-| Craft Economy            | `craft`       |          |             |
-| CranePay                 | `cp`          | `cpt`    | `cpr`       |
-| Crescent                 | `cre`         |          |             |
-| Cronos                   | `crc`         |          |             |
-| Crypto Chain             | `cro`         | `tcro`   |             |
-| Cudos                    | `cudos`       |          |             |
-| Cyber                    | `cyber`       |          |             |
-| Cyberyen                 | `cy`          | `tcy`    | `rcy`       |
-| Decentr                  | `decentr`     |          |             |
-| Desmos                   | `desmos`      |          |             |
-| dHealth                  | `dh`          |          |             |
-| Dig Chain                | `dig`         |          |             |
-| DigiByte                 | `dgb`         | `dgbt`   | `dgbrt`     |
-| Dora Vota                | `dora`        |          |             |
-| Developer Network        | `dev`         |          |             |
-| Dungeon Network          | `dungeon`     |          |             |
-| dYdX Protocol            | `dydx`        |          |             |
-| Dymension                | `dym`         |          |             |
-| Dyson Protocol           | `dys`         |          |             |
-| Echelon                  | `echelon`     |          |             |
-| e-Money                  | `emoney`      |          |             |
-| Elys Network             | `elys`        |          |             |
-| EmpowerChain             | `empower`     |          |             |
-| Epix                     | `epix`        |          |             |
-| Ethos                    | `ethos`       |          |             |
-| Evmos                    | `evmos`       |          |             |
-| Fetch                    | `fetch`       |          |             |
-| Finschia                 | `link`        | `tlink`  |             |
-| FirmaChain               | `firma`       |          |             |
-| Fren.ai                  | `fren`        | `fren-1` |             |
-| FujiCoin                 | `fc`          | `tf`     | `fcrt`      |
-| Furya                    | `furya`       |          |             |
-| f(x)Core                 | `fx`          |          |             |
-| Galaxy                   | `galaxy`      |          |             |
-| GovGen                   | `govgen`      |          |             |
-| Wormhole Gateway         | `wormhole`    |          |             |
-| GenesisL1                | `genesis`     |          |             |
-| GGEZ1 Chain              | `ggez`        |          |             |
-| Gitopia                  | `gitopia`     |          |             |
-| GlobalBoost-Y            | `gb`          | `gbt`    | `gbrt`      |
-| Golden Gate              | `ggx`         | `ggxt`   |             |
-| Gravity Bridge           | `gravity`     |          |             |
-| Groestlcoin              | `grs`         | `tgrs`   | `grsrt`     |
-| Handshake                | `hs`          | `ts`     | `rs`        |
-| Haqq Network             | `haqq`        |          |             |
-| Hash                     | `pb`          | `tp`     |             |
-| HashKey Chain            | `hsk`         | `hst`    |             |
-| Hedge                    | `hedge`       |          |             |
-| HeliChain                | `heli`        |          |             |
-| Highbury                 | `fury`        |          |             |
-| HoneyWood                | `bears`       |          |             |
-| Humans                   | `human`       |          |             |
-| Hypersign                | `hid`         |          |             |
-| IDEP                     | `idep`        |          |             |
-| Imversed                 | `imv`         |          |             |
-| Int3face                 | `int3`        |          |             |
-| Initia                   | `init`        |          |             |
-| Injective                | `inj`         |          |             |
-| IOTA                     | `iota`        | `atoi`   |             |
-| IoTeX                    | `io`          | `it`     |             |
-| IRISnet                  | `iaa`         |          |             |
-| Impact Hub               | `ixo`         |          |             |
-| Jackal                   | `jkl`         |          |             |
-| Juno                     | `juno`        |          |             |
-| Joltify                  | `jolt`        |          |             |
-| Kava                     | `kava`        |          |             |
-| Ki                       | `ki`          |          |             |
-| Kima Network             | `kima`        |          |             |
-| Kira Network             | `kira`        |          |             |
-| Konstellation            | `darc`        |          |             |
-| kopi                     | `kopi`        |          |             |
-| Kujira                   | `kujira`      |          |             |
-| Kylacoin                 | `kc`          | `tkc`    | `kcrt`      |
-| KYVE                     | `kyve`        |          |             |
-| Lambda                   | `lamb`        |          |             |
-| LatticeX                 | `pla`         | `plt`    |             |
-| Lava                     | `lava@`       | `lava@`  |             |
-| Lefeef                   | `lefeef`      |          |             |
-| LikeCoin                 | `like`        |          |             |
-| Litecoin                 | `ltc`         | `tltc`   | `rltc`      |
-| Logos                    | `logos`       |          |             |
-| Loop                     | `loop`        |          |             |
-| Lorenzo                  | `lrz`         |          |             |
-| Loyal                    | `loyal`       |          |             |
-| Lum Network              | `lum`         |          |             |
-| LumenX                   | `lumen`       |          |             |
-| Lyncoin                  | `lc`          | `tlc`    | `lcrt`      |
-| Mande Network            | `mande`       |          |             |
-| MANTRA Chain             | `mantra`      |          |             |
-| Mars Protocol            | `mars`        |          |             |
-| Maya Protocol            | `maya`        | `smaya`  |             |
-| Medas Digital            | `medas`       |          |             |
-| Medibloc                 | `panacea`     |          |             |
-| MEME                     | `meme`        |          |             |
-| MetaNova Verse           | `mnova`       |          |             |
-| Microtick                | `micro`       |          |             |
-| Migaloo                  | `migaloo`     |          |             |
-| MilkyWay                 | `milk`        |          |             |
-| Mises                    | `mises`       |          |             |
-| Monacoin                 | `mona`        | `tmona`  | `rmona`     |
-| Moneta Coin              | `moneta`      |          |             |
-| MTGBP                    | `mtgbp`       | `tmtgbp` | `rmtgbp`    |
-| MUN Blockchain           | `mun`         |          |             |
-| Mutelandia Network       | `mute`        |          |             |
-| Myriad                   | `my`          | `tm`     |             |
-| Mythos                   | `mythos`      |          |             |
-| Namecoin                 | `nc`          | `tn`     | `ncrt`      |
-| Neura                    | `neura`       |          |             |
-| Neutaro                  | `neutaro`     |          |             |
-| Neutron                  | `neutron`     |          |             |
-| Nexa                     | `nexa`        |`nexatest`| `nexareg`   |
-| Nibiru                   | `nibi`        |          |             |
-| Nillion                  | `nillion`     |          |             |
-| Nim                      | `nim`         |          |             |
-| Noble                    | `noble`       |          |             |
-| Nois                     | `nois`        |          |             |
-| Nomic                    | `nomic`       |          |             |
-| Nyx                      | `n`           |          |             |
-| Oasis Network            | `oasis`       | `oasis`  |             |
-| Octa                     | `octa`        |          |             |
-| Odin Protocol            | `odin`        |          |             |
-| OKExChain                | `ex`          |          |             |
-| OKP4                     | `okp4`        |          |             |
-| Omni                     | `o`           | `to`     | `ocrt`      |
-| OmniFlix                 | `omniflix`    |          |             |
-| OPCT Chain               | `opct`        |          |             |
-| Onomy                    | `onomy`       |          |             |
-| Oraichain                | `orai`        |          |             |
-| Osmosis                  | `osmo`        |          |             |
-| Paloma                   | `paloma`      |          |             |
-| Passage                  | `pasg`        |          |             |
-| Peercoin                 | `xpc`         | `tpc`    |             |
-| Persistence              | `persistence` |          |             |
-| Picasso                  | `pica`        |          |             |
-| PKT                      | `pkt`         | `tpk`    |             |
-| Planq                    | `plq`         |          |             |
-| PlatON                   | `lat`         | `lax`    |             |
-| Point Network            | `point`       | `xpoint` |             |
-| Provenance               | `pb`          | `tp`     |             |
-| Pryzm                    | `pryzm`       |          |             |
-| Pundi X Chain            | `px`          |          |             |
-| Pylons                   | `pylo`        |          |             |
-| QFS                      | `qfs`         | `tqfs`   | `rqfs  `    |
-| Quantum Resistant Ledger | `qrl`         | `tqrl`   | `qrlrt`     |
-| Quasar                   | `quasar`      |          |             |
-| Quicksilver              | `quick`       |          |             |
-| Qwoyn Blockchain         | `qwoyn`       |          |             |
-| Ravencoin                | `rc`          | `tr`     | `rcrt`      |
-| Realio Network           | `realio`      |          |             |
-| Rebus                    | `rebus`       |          |             |
-| Regen                    | `regen`       |          |             |
-| Riecoin                  | `ric`         | `tric`   | `rric`      |
-| Rizon                    | `rizon`       |          |             |
-| Router Protocol          | `router`       |          |             |
-| Saga                     | `saga`        | `tsaga`  |             |
-| Scash                    | `scash`       | `tscash` | `rscash`    |
-| Scorum Network           | `scorum`      |          |             |
-| SEDA                     | `seda`        |          |             |
-| Secret Network           | `secret`      |          |             |
-| Sei                      | `sei`         |          |             |
-| Self Chain               | `self`        |          |             |
-| Sentinel                 | `sent`        |          |             |
-| SGE Network              | `sge`         |          |             |
-| ShareLedger              | `shareledger` |          |             |
-| Shentu                   | `shentu`      |          |             |
-| Shido                    | `shido`       |          |             |
-| Shimmer                  | `smr`         | `rms`    |             |
-| Side Chain               | `side`        |          |             |
-| Sifchain                 | `sif`         |          |             |
-| SIX Protocol             | `6x`          |          |             |
-| Sommelier                | `somm`        |          |             |
-| Sonr                     | `idx`         |          |             |
-| Source                   | `source`      |          |             |
-| Spacemesh                | `sm`          | `stest`  |             |
-| StaFiHub                 | `stafi`       |          |             |
-| Stargaze                 | `stars`       |          |             |
-| Starname                 | `star`        |          |             |
-| Straightedge             | `str`         |          |             |
-| Stratos                  | `st`          |          |             |
-| Stride                   | `stride`      |          |             |
-| Sugarchain               | `sugar`       | `tugar`  | `rugar`     |
-| Susucoin                 | `susu`        | `tutu`   | `ruru`      |
-| Symphony                 | `symphony`    |          |             |
-| Synternet                | `synt`        | `amber`  |             |
-| Syscoin                  | `sys`         | `tsys`   | `scrt`      |
-| TakeTitan                | `ttnc`        | `tttnc`  | `rttnc`     |
-| Tenet                    | `tenet`       |          |             |
-| Teritori                 | `tori`        |          |             |
-| Terp                     | `terp`        |          |             |
-| Terra                    | `terra`       |          |             |
-| Tgrade                   | `tgrade`      |          |             |
-| Thorchain                | `thor`        |          |             |
-| Titan                    | `titan`       |          |             |
-| Ulas                     | `ulas`        |          |             |
-| Umee                     | `umee`        |          |             |
-| Unification              | `und`         |          |             |
-| UnUniFi                  | `ununifi`     |          |             |
-| Unit-e                   | `ue`          | `tue`    | `uert`      |
-| Uptick                   | `uptick`      |          |             |
-| Vertcoin                 | `vtc`         | `tvtc`   |             |
-| Viacoin                  | `via`         | `tvia`   |             |
-| Vidulum                  | `vdl`         | `tvdl`   |             |
-| VinceChain               | `vce`         |          |             |
-| VIPSTARCOIN              | `vips`        | `tvips`  |             |
-| Wpc                      | `wpc`         |          |             |
-| Xion                     | `xion`        | `txion`  |             |
-| XPLA                     | `xpla`        |          |             |
-| YeeCo                    | `yee`         | `tyee`   |             |
-| Zen Protocol             | `zen`         | `tzn`    |             |
-| ZetaChain                | `zeta`        |          |             |
-| ZIGChain                 | `zig`         |          |             |
-| Zilliqa                  | `zil`         | `tzil`   |             |
+| Coin                     | Mainnet       | Testnet    | Regtest     |
+| ------------------------ | ------------- | ---------- | ----------- |
+| 8ball                    | `8ball`       |            |             |
+| Aaron Network            | `aaron`       |            |             |
+| Acrechain                | `acre`        |            |             |
+| Agoric                   | `agoric`      |            |             |
+| AIOZ Network             | `aioz`        |            |             |
+| Akash                    | `akash`       |            |             |
+| Allora                   | `allo`        |            |             |
+| Andromeda                | `andr`        |            |             |
+| Alaya                    | `atp`         | `atx`      |             |
+| Althea                   | `althea`      |            |             |
+| Archway                  | `archway`     | `const`    |             |
+| Apc                      | `apc`         |            |             |
+| Arkhadian                | `arkh`        |            |             |
+| AssetMantle              | `mantle`      |            |             |
+| Athena                   | `ath`         | `atest`    |             |
+| AtomOne                  | `atone`       |            |             |
+| Aura Network             | `aura`        |            |             |
+| Axelar                   | `axelar`      |            |             |
+| Axone                    | `axone`       |            |             |
+| Babylon                  | `bbn`         |            |             |
+| BARE                     | `bare`        | `tbare`    | `bart`      |
+| Band Protocol            | `band`        |            |             |
+| BeeZee                   | `bze`         | `tbz`      |             |
+| Bellcoin                 | `bm`          | `bt`       | `br`        |
+| BeOne Chain              | `boc`         | `tboc`     |             |
+| Binance Chain            | `bnb`         |            |             |
+| BitCanna                 | `bcna`        |            |             |
+| BitBadges                | `bb`          |            |             |
+| Bitcoin                  | `bc`          | `tb`       | `bcrt`      |
+| Bitcoin Atom             | `bca`         | `tbca`     | `bcart`     |
+| Bitcoin Gold             | `btg`         | `tbtg`     |             |
+| Bitcoin Platinum         | `btp`         | `tbtp`     |             |
+| Bitcoin Post-Quantum     | `pq`          | `tq`       | `pqrt`      |
+| Bitcoin Private          | `btcp`        | `tbtcp`    | `regbtcp`   |
+| Bitcore                  | `btx`         | `tbtx`     |             |
+| BitSong                  | `bitsong`     |            |             |
+| BitZeny                  | `bz`          | `tz`       | `rz`        |
+| Blackcoin                | `blk`         | `tblk`     | `blrt`      |
+| Blacknet                 | `blacknet`    |            | `rblacknet` |
+| BlockX                   | `blockx`      |            |             |
+| BlueChip                 | `bcp`         |            |             |
+| Bluzelle                 | `bluzelle`    |            |             |
+| bostrom                  | `bostrom`     |            |             |
+| Bouachain                | `bouachain`   |            |             |
+| Canto                    | `canto`       |            |             |
+| Carbon                   | `swth`        |            |             |
+| Celestia                 | `celestia`    |            |             |
+| Cerberus                 | `cerberus`    |            |             |
+| Chain4Energy             | `c4e`         |            |             |
+| cheqd                    | `cheqd`       |            |             |
+| Chia                     | `xch`         | `txch`     |             |
+| Chihuahua                | `chihuahua`   |            |             |
+| Chimba                   | `chimba`      |            |             |
+| Chronic Chain            | `chronic`     |            |             |
+| Cifer                    | `cife`        | `cift`     |             |
+| City Coin                | `city`        | `tcity`    |             |
+| Cnho Stables             | `cnho`        |            |             |
+| Comdex                   | `comdex`      |            |             |
+| Commercio                | `did:com:`    |            |             |
+| Composable               | `centauri`    |            |             |
+| ConsciousDAO             | `cvn`         |            |             |
+| Coreum                   | `core`        | `testcore` |             |
+| Cosmos Hub               | `cosmos`      |            |             |
+| Coss Chain               | `coss`        | `tcoss`    |             |
+| CPUchain                 | `cpu`         | `tcpu`     | `rcpu`      |
+| Craft Economy            | `craft`       |            |             |
+| CranePay                 | `cp`          | `cpt`      | `cpr`       |
+| Crescent                 | `cre`         |            |             |
+| Cronos                   | `crc`         |            |             |
+| Crypto Chain             | `cro`         | `tcro`     |             |
+| Cudos                    | `cudos`       |            |             |
+| Cyber                    | `cyber`       |            |             |
+| Cyberyen                 | `cy`          | `tcy`      | `rcy`       |
+| Decentr                  | `decentr`     |            |             |
+| Desmos                   | `desmos`      |            |             |
+| dHealth                  | `dh`          |            |             |
+| Dig Chain                | `dig`         |            |             |
+| DigiByte                 | `dgb`         | `dgbt`     | `dgbrt`     |
+| Dora Vota                | `dora`        |            |             |
+| Developer Network        | `dev`         |            |             |
+| Dungeon Network          | `dungeon`     |            |             |
+| dYdX Protocol            | `dydx`        |            |             |
+| Dymension                | `dym`         |            |             |
+| Dyson Protocol           | `dys`         |            |             |
+| Echelon                  | `echelon`     |            |             |
+| e-Money                  | `emoney`      |            |             |
+| Elys Network             | `elys`        |            |             |
+| EmpowerChain             | `empower`     |            |             |
+| Epix                     | `epix`        |            |             |
+| Ethos                    | `ethos`       |            |             |
+| Evmos                    | `evmos`       |            |             |
+| Fetch                    | `fetch`       |            |             |
+| Finschia                 | `link`        | `tlink`    |             |
+| FirmaChain               | `firma`       |            |             |
+| Fren.ai                  | `fren`        | `fren-1`   |             |
+| FujiCoin                 | `fc`          | `tf`       | `fcrt`      |
+| Furya                    | `furya`       |            |             |
+| f(x)Core                 | `fx`          |            |             |
+| Galaxy                   | `galaxy`      |            |             |
+| GovGen                   | `govgen`      |            |             |
+| Wormhole Gateway         | `wormhole`    |            |             |
+| GenesisL1                | `genesis`     |            |             |
+| GGEZ1 Chain              | `ggez`        |            |             |
+| Gitopia                  | `gitopia`     |            |             |
+| GlobalBoost-Y            | `gb`          | `gbt`      | `gbrt`      |
+| Golden Gate              | `ggx`         | `ggxt`     |             |
+| Gravity Bridge           | `gravity`     |            |             |
+| Groestlcoin              | `grs`         | `tgrs`     | `grsrt`     |
+| Handshake                | `hs`          | `ts`       | `rs`        |
+| Haqq Network             | `haqq`        |            |             |
+| Hash                     | `pb`          | `tp`       |             |
+| HashKey Chain            | `hsk`         | `hst`      |             |
+| Hedge                    | `hedge`       |            |             |
+| HeliChain                | `heli`        |            |             |
+| Highbury                 | `fury`        |            |             |
+| HoneyWood                | `bears`       |            |             |
+| Humans                   | `human`       |            |             |
+| Hypersign                | `hid`         |            |             |
+| IDEP                     | `idep`        |            |             |
+| Imversed                 | `imv`         |            |             |
+| Int3face                 | `int3`        |            |             |
+| Initia                   | `init`        |            |             |
+| Injective                | `inj`         |            |             |
+| IOTA                     | `iota`        | `atoi`     |             |
+| IoTeX                    | `io`          | `it`       |             |
+| IRISnet                  | `iaa`         |            |             |
+| Impact Hub               | `ixo`         |            |             |
+| Jackal                   | `jkl`         |            |             |
+| Juno                     | `juno`        |            |             |
+| Joltify                  | `jolt`        |            |             |
+| Kava                     | `kava`        |            |             |
+| Ki                       | `ki`          |            |             |
+| Kima Network             | `kima`        |            |             |
+| Kira Network             | `kira`        |            |             |
+| Konstellation            | `darc`        |            |             |
+| kopi                     | `kopi`        |            |             |
+| Kujira                   | `kujira`      |            |             |
+| Kylacoin                 | `kc`          | `tkc`      | `kcrt`      |
+| KYVE                     | `kyve`        |            |             |
+| Lambda                   | `lamb`        |            |             |
+| LatticeX                 | `pla`         | `plt`      |             |
+| Lava                     | `lava@`       | `lava@`    |             |
+| Lefeef                   | `lefeef`      |            |             |
+| LikeCoin                 | `like`        |            |             |
+| Litecoin                 | `ltc`         | `tltc`     | `rltc`      |
+| Logos                    | `logos`       |            |             |
+| Loop                     | `loop`        |            |             |
+| Lorenzo                  | `lrz`         |            |             |
+| Loyal                    | `loyal`       |            |             |
+| Lum Network              | `lum`         |            |             |
+| LumenX                   | `lumen`       |            |             |
+| Lyncoin                  | `lc`          | `tlc`      | `lcrt`      |
+| Mande Network            | `mande`       |            |             |
+| Manifest Network         | `manifest`    |            |             |
+| MANTRA Chain             | `mantra`      |            |             |
+| Mars Protocol            | `mars`        |            |             |
+| Maya Protocol            | `maya`        | `smaya`    |             |
+| Medas Digital            | `medas`       |            |             |
+| Medibloc                 | `panacea`     |            |             |
+| MEME                     | `meme`        |            |             |
+| MetaNova Verse           | `mnova`       |            |             |
+| Microtick                | `micro`       |            |             |
+| Migaloo                  | `migaloo`     |            |             |
+| MilkyWay                 | `milk`        |            |             |
+| Mises                    | `mises`       |            |             |
+| Monacoin                 | `mona`        | `tmona`    | `rmona`     |
+| Moneta Coin              | `moneta`      |            |             |
+| MTGBP                    | `mtgbp`       | `tmtgbp`   | `rmtgbp`    |
+| MUN Blockchain           | `mun`         |            |             |
+| Mutelandia Network       | `mute`        |            |             |
+| Myriad                   | `my`          | `tm`       |             |
+| Mythos                   | `mythos`      |            |             |
+| Namecoin                 | `nc`          | `tn`       | `ncrt`      |
+| Neura                    | `neura`       |            |             |
+| Neutaro                  | `neutaro`     |            |             |
+| Neutron                  | `neutron`     |            |             |
+| Nexa                     | `nexa`        | `nexatest` | `nexareg`   |
+| Nibiru                   | `nibi`        |            |             |
+| Nillion                  | `nillion`     |            |             |
+| Nim                      | `nim`         |            |             |
+| Noble                    | `noble`       |            |             |
+| Nois                     | `nois`        |            |             |
+| Nomic                    | `nomic`       |            |             |
+| Nyx                      | `n`           |            |             |
+| Oasis Network            | `oasis`       | `oasis`    |             |
+| Octa                     | `octa`        |            |             |
+| Odin Protocol            | `odin`        |            |             |
+| OKExChain                | `ex`          |            |             |
+| OKP4                     | `okp4`        |            |             |
+| Omni                     | `o`           | `to`       | `ocrt`      |
+| OmniFlix                 | `omniflix`    |            |             |
+| OPCT Chain               | `opct`        |            |             |
+| Onomy                    | `onomy`       |            |             |
+| Oraichain                | `orai`        |            |             |
+| Osmosis                  | `osmo`        |            |             |
+| Paloma                   | `paloma`      |            |             |
+| Passage                  | `pasg`        |            |             |
+| Peercoin                 | `xpc`         | `tpc`      |             |
+| Persistence              | `persistence` |            |             |
+| Picasso                  | `pica`        |            |             |
+| PKT                      | `pkt`         | `tpk`      |             |
+| Planq                    | `plq`         |            |             |
+| PlatON                   | `lat`         | `lax`      |             |
+| Point Network            | `point`       | `xpoint`   |             |
+| Provenance               | `pb`          | `tp`       |             |
+| Pryzm                    | `pryzm`       |            |             |
+| Pundi X Chain            | `px`          |            |             |
+| Pylons                   | `pylo`        |            |             |
+| QFS                      | `qfs`         | `tqfs`     | `rqfs  `    |
+| Quantum Resistant Ledger | `qrl`         | `tqrl`     | `qrlrt`     |
+| Quasar                   | `quasar`      |            |             |
+| Quicksilver              | `quick`       |            |             |
+| Qwoyn Blockchain         | `qwoyn`       |            |             |
+| Ravencoin                | `rc`          | `tr`       | `rcrt`      |
+| Realio Network           | `realio`      |            |             |
+| Rebus                    | `rebus`       |            |             |
+| Regen                    | `regen`       |            |             |
+| Riecoin                  | `ric`         | `tric`     | `rric`      |
+| Rizon                    | `rizon`       |            |             |
+| Router Protocol          | `router`      |            |             |
+| Saga                     | `saga`        | `tsaga`    |             |
+| Scash                    | `scash`       | `tscash`   | `rscash`    |
+| Scorum Network           | `scorum`      |            |             |
+| SEDA                     | `seda`        |            |             |
+| Secret Network           | `secret`      |            |             |
+| Sei                      | `sei`         |            |             |
+| Self Chain               | `self`        |            |             |
+| Sentinel                 | `sent`        |            |             |
+| SGE Network              | `sge`         |            |             |
+| ShareLedger              | `shareledger` |            |             |
+| Shentu                   | `shentu`      |            |             |
+| Shido                    | `shido`       |            |             |
+| Shimmer                  | `smr`         | `rms`      |             |
+| Side Chain               | `side`        |            |             |
+| Sifchain                 | `sif`         |            |             |
+| SIX Protocol             | `6x`          |            |             |
+| Sommelier                | `somm`        |            |             |
+| Sonr                     | `idx`         |            |             |
+| Source                   | `source`      |            |             |
+| Spacemesh                | `sm`          | `stest`    |             |
+| StaFiHub                 | `stafi`       |            |             |
+| Stargaze                 | `stars`       |            |             |
+| Starname                 | `star`        |            |             |
+| Straightedge             | `str`         |            |             |
+| Stratos                  | `st`          |            |             |
+| Stride                   | `stride`      |            |             |
+| Sugarchain               | `sugar`       | `tugar`    | `rugar`     |
+| Susucoin                 | `susu`        | `tutu`     | `ruru`      |
+| Symphony                 | `symphony`    |            |             |
+| Synternet                | `synt`        | `amber`    |             |
+| Syscoin                  | `sys`         | `tsys`     | `scrt`      |
+| TakeTitan                | `ttnc`        | `tttnc`    | `rttnc`     |
+| Tenet                    | `tenet`       |            |             |
+| Teritori                 | `tori`        |            |             |
+| Terp                     | `terp`        |            |             |
+| Terra                    | `terra`       |            |             |
+| Tgrade                   | `tgrade`      |            |             |
+| Thorchain                | `thor`        |            |             |
+| Titan                    | `titan`       |            |             |
+| Ulas                     | `ulas`        |            |             |
+| Umee                     | `umee`        |            |             |
+| Unification              | `und`         |            |             |
+| UnUniFi                  | `ununifi`     |            |             |
+| Unit-e                   | `ue`          | `tue`      | `uert`      |
+| Uptick                   | `uptick`      |            |             |
+| Vertcoin                 | `vtc`         | `tvtc`     |             |
+| Viacoin                  | `via`         | `tvia`     |             |
+| Vidulum                  | `vdl`         | `tvdl`     |             |
+| VinceChain               | `vce`         |            |             |
+| VIPSTARCOIN              | `vips`        | `tvips`    |             |
+| Wpc                      | `wpc`         |            |             |
+| Xion                     | `xion`        | `txion`    |             |
+| XPLA                     | `xpla`        |            |             |
+| YeeCo                    | `yee`         | `tyee`     |             |
+| Zen Protocol             | `zen`         | `tzn`      |             |
+| ZetaChain                | `zeta`        |            |             |
+| ZIGChain                 | `zig`         |            |             |
+| Zilliqa                  | `zil`         | `tzil`     |             |
 
 ## Non-Segwit-compatible uses of Bech32 / Bech32m
 
@@ -331,10 +332,10 @@ checksum versus the one used in Bech32 in order to support enhanced error
 correction. Codex32 uses the same notion of a human-readable part and the same
 set of 32 characters as other Bech32 formats.
 
-| Application          | Human-readable part  |
-| -------------------- | -------------------- |
-| CLN's HSM secret     | `cl`                 |
-| BIP-0032 master seed | `ms`                 |
+| Application          | Human-readable part |
+| -------------------- | ------------------- |
+| CLN's HSM secret     | `cl`                |
+| BIP-0032 master seed | `ms`                |
 
 ## Libraries
 


### PR DESCRIPTION
This pull request adds the Manifest Mainnet to the slip-0173 registry. 

[Network Details](https://github.com/chalabi2/chain-registry/tree/chalabi/manifest-mainnet)

[Blockchain Github](https://github.com/liftedinit/manifest-app)
