### PR TITLE
Add Maniest Network to the slip-0173 registry

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -176,6 +176,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | LumenX                   | `lumen`       |          |             |
 | Lyncoin                  | `lc`          | `tlc`    | `lcrt`      |
 | Mande Network            | `mande`       |          |             |
+| Manifest Network         | `manifest`    |          |             |
 | MANTRA Chain             | `mantra`      |          |             |
 | Mars Protocol            | `mars`        |          |             |
 | Maya Protocol            | `maya`        | `smaya`  |             |


### PR DESCRIPTION
This PR registers the Manifest Network bech32 prefix in the slip-0173 registry

[Network Info](https://github.com/cosmos/chain-registry/) 
[Blockchain](https://github.com/liftedinit/manifest-app)
