### PR TITLE
slip-0044: add ANLOG

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1282,6 +1282,7 @@ All these constants are used as hardened derivation.
 | 11743      | 0x80002ddf                    | TNKR    | Tinkernet                         |
 | 12345      | 0x80003039                    | IPOS    | IPOS                              |
 | 12586      | 0x8000312a                    | MINA    | Mina                              |
+| 12850      | 0x80003232                    | ANLOG   | Analog Timechain                  |
 | 13107      | 0x80003333                    | BTY     | BitYuan                           |
 | 13108      | 0x80003334                    | YCC     | Yuan Chain Coin                   |
 | 13381      | 0x80003445                    | PHX     | Phoenix                           |


### PR DESCRIPTION
This add Analog Timechain to slip 44. `12850` is also our chains SS58 prefix.