### PR TITLE
Add JunkCoin (JKC) to SLIP-0044

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1135,6 +1135,7 @@ All these constants are used as hardened derivation.
 | 2001       | 0x800007d1                    | MNP     | MNPCoin                           |
 | 2002       | 0x800007d2                    | MLN     | Miraland                          |
 | 2003       | 0x800007d3                    | ISNA    | iSarrana                          |
+| 2013       | 0x800007dd                    | JKC     | Junkcoin                          |
 | 2015       | 0x800007df                    | TEER    | Integritee                        |
 | 2017       | 0x800007e1                    | KIN     | Kin                               |
 | 2018       | 0x800007e2                    | EOSC    | EOSClassic                        |


### PR DESCRIPTION
This PR adds Junkcoin (JKC) to SLIP-0044 with the following details:

- **Coin Type:** `2013`
- **Hexadecimal Representation:** `0x800007dd`
- **Symbol:** `JKC`
- **Coin Name:** `Junkcoin`
- **Reason for Inclusion:** Junkcoin was founded in 2013 and follows BIP-44.

Junkcoin implements BIP-44-compatible wallets, and we provide support for hierarchical deterministic (HD) wallets.

Our core repo can be found [here](https://github.com/Junkcoin-Foundation/junkcoin-core)

Please review and merge. Thank you!
