### PR TITLE
Add hive to slip 0044 and slip 0048 lists

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1179,6 +1179,7 @@ All these constants are used as hardened derivation.
 | 3000       | 0x80000bb8                    | SM      | Stealth Message                   |
 | 3003       | 0x80000bbb                    | LUX     | LUX                               |
 | 3030       | 0x80000bd6                    | HBAR    | Hedera HBAR                       |
+| 3054       | 0x80000bee                    | HIVE    | Hive Blockchain                   |
 | 3077       | 0x80000c05                    | COS     | Contentos                         |
 | 3276       | 0x80000ccc                    | CCC     | CodeChain                         |
 | 3344       | 0x80000d10                    | PLMC    | Polimec                           |

--- a/slip-0048.md
+++ b/slip-0048.md
@@ -138,7 +138,7 @@ Index          | Network      | Roles
 0x0000000a     | ONEGRAM      | `0x0`: owner, `0x1`: active
 0x0000000b     | BRAVO        | `0x0`: owner, `0x1`: active, `0x3`: memo, `0x4`: posting
 0x0000000c     | DECENT       | `0x0`: owner, `0x1`: active, `0x3`: memo
-0x0000000d     | Hive         | `0x0`: owner, `0x1`: active, `0x3`: memo, `0x4`: posting
+0x00000bee     | Hive         | `0x0`: owner, `0x1`: active, `0x3`: memo, `0x4`: posting
 0x00001388     | Vet The Vote | `0x0`: owner, `0x1`: active, `0x3`: memo, `0x4`: posting, `0x5`: comms
 0x000014da     | Keet         | `0x0`: owner
 
@@ -152,7 +152,9 @@ EOS        | owner         | first          | first     | m / 48' / 4'    / 0' /
 FIBOS      | owner         | first          | first     | m / 48' / 5'    / 0' / 0' / 0'
 BOS        | owner         | first          | first     | m / 48' / 9'    / 0' / 0' / 0'
 ONEGRAM    | owner         | first          | first     | m / 48' / 10'   / 0' / 0' / 0'
+HIVE       | active        | first          | first     | m / 48' / 3054' / 1' / 0' / 0'
 V12        | comms         | first          | first     | m / 48' / 5000' / 5' / 0' / 0'
+
 
 ## References
 


### PR DESCRIPTION
Hive is a blockchain is powering a blogging community and ecosystem of decentralized apps.
You can find more information in the official repositories:
- https://github.com/openhive-network/hive
- https://gitlab.syncad.com/hive/hive

like also working community front-end applications:
- https://hive.blog
- https://blog.openhive.network

We would like to be enlisted on official chain & token list, due to lately done work related to MetaMask wallet integration.

