### PR TITLE
Add Ezcon Blockchain (EZC) to SLIP-0044

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1181,6 +1181,7 @@ All these constants are used as hardened derivation.
 | 3030       | 0x80000bd6                    | HBAR    | Hedera HBAR                       |
 | 3054       | 0x80000bee                    | HIVE    | Hive Blockchain                   |
 | 3077       | 0x80000c05                    | COS     | Contentos                         |
+| 3131       | 0x80000c3b                    | EZC     | Ezcon Blockchain                  |
 | 3276       | 0x80000ccc                    | CCC     | CodeChain                         |
 | 3344       | 0x80000d10                    | PLMC    | Polimec                           |
 | 3333       | 0x80000d05                    | SXP     | Solar                             |


### PR DESCRIPTION
Hello SatoshiLabs team,

I would like to propose the addition of EZCON Blockchain to the SLIP-44 coin type list with the index 0x80000c3b (decimal: 3131).

Project: EZCON Blockchain. 
Coin Name: EZCON. 
Description: EZCON is a new blockchain project designed to facilitate decentralized applications with high scalability and low transaction costs.
Purpose: This coin type registration will enable compatibility with BIP-44 compliant wallets (e.g., Ledger, Trezor) and ensure a standardized derivation path for EZCON addresses.
Proposed Index: 0x80000c3b (3131 in decimal) - I’ve checked the current SLIP-44 list, and this index appears to be unused.
Please let me know if additional details or clarifications are needed. Thank you for considering this request!

Best regards,
EZCON CTO, Pon Le