### PR TITLE
Add Cross Chain to Slip-0044

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1056,6 +1056,7 @@ All these constants are used as hardened derivation.
 | 1028       | 0x80000404                    | PLS     | Pulse Coin                        |
 | 1032       | 0x80000408                    | BTCR    | BTCR                              |
 | 1042       | 0x80000412                    | MFID    | Moonfish ID                       |
+| 1100       | 0x8000044c                    | CROSS   | Cross Chain                       |
 | 1111       | 0x80000457                    | BBC     | Big Bitcoin                       |
 | 1116       | 0x8000045c                    | CORE    | Core                              |
 | 1120       | 0x80000460                    | RISE    | RISE                              |


### PR DESCRIPTION
This PR introduces the CROSS blockchain (to.nexus) to the SLIP-0044 registry, assigning it the unique coin type 1100. This will enable seamless integration for HD wallets supporting SLIP-0044, ensuring compatibility and enhancing the ecosystem for CROSS users.