### PR TITLE
Add Satoxcoin (SATOX) to SLIP-0044 coin type registry

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1268,7 +1268,7 @@ All these constants are used as hardened derivation.
 | 9004       | 0x8000232c                    | STRK    | StarkNet                          |
 | 9005       | 0x8000232d                    | AVAXC   | Avalanche C-Chain                 |
 | 9006       | 0x8000232e                    | BSC     | Binance Smart Chain               |
-| 9007       | 0x80002367                    | SATOX   | Satoxcoin                         |
+| 9007       | 0x8000232f                    | SATOX   | Satoxcoin                         |
 | 9797       | 0x80002645                    | NRG     | Energi                            |
 | 9888       | 0x800026a0                    | BTF     | Bitcoin Faith                     |
 | 9969       | 0x800026f1                    | OSMI    | Osmium                            |

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1268,6 +1268,7 @@ All these constants are used as hardened derivation.
 | 9004       | 0x8000232c                    | STRK    | StarkNet                          |
 | 9005       | 0x8000232d                    | AVAXC   | Avalanche C-Chain                 |
 | 9006       | 0x8000232e                    | BSC     | Binance Smart Chain               |
+| 9007       | 0x80002367                    | SATOX   | Satoxcoin                         |
 | 9797       | 0x80002645                    | NRG     | Energi                            |
 | 9888       | 0x800026a0                    | BTF     | Bitcoin Faith                     |
 | 9969       | 0x800026f1                    | OSMI    | Osmium                            |


### PR DESCRIPTION
## Summary

This PR proposes to assign coin type `9007'` to **Satoxcoin (SATOX)** in the SLIP-0044 registry.

---

## Details

- **Project Name:** Satoxcoin
- **Ticker Symbol:** SATOX
- **Website:** [https://satoverse.io](https://satoverse.io)
- **Source Code:** [https://github.com/satoverse/satoxcoin](https://github.com/satoverse/satoxcoin)
- **Proposed Coin Type:** `9007'`

Satoxcoin is a Bitcoin- and Ravencoin-based blockchain with its own network, consensus rules, and economic model. It requires a dedicated BIP44 coin type to enable integration with hardware wallets (e.g., Ledger, Trezor) and other hierarchical deterministic (HD) wallets.

Although Satoxcoin is derived from Ravencoin, it operates independently and cannot share the same coin type (`175'`) without risk of address space collisions.

We propose using coin type `9007'`, which is currently unassigned.

---

## Justification

- Ensures safe, deterministic key derivation paths for Satoxcoin wallets.
- Enables integration with hardware and HD wallet infrastructure.
- Avoids conflicts with Ravencoin or other SLIP-0044 entries.

Thank you for your consideration.
