### PR TITLE
Add Bit (B1T) coin type 3141 to SLIP-0044

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1183,6 +1183,7 @@ All these constants are used as hardened derivation.
 | 3054       | 0x80000bee                    | HIVE    | Hive Blockchain                   |
 | 3077       | 0x80000c05                    | COS     | Contentos                         |
 | 3131       | 0x80000c3b                    | EZC     | Ezcon Blockchain                  |
+| 3141       | 0x80000c45                    | B1T     | Bit
 | 3276       | 0x80000ccc                    | CCC     | CodeChain                         |
 | 3344       | 0x80000d10                    | PLMC    | Polimec                           |
 | 3333       | 0x80000d05                    | SXP     | Solar                             |

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1183,7 +1183,7 @@ All these constants are used as hardened derivation.
 | 3054       | 0x80000bee                    | HIVE    | Hive Blockchain                   |
 | 3077       | 0x80000c05                    | COS     | Contentos                         |
 | 3131       | 0x80000c3b                    | EZC     | Ezcon Blockchain                  |
-| 3141       | 0x80000c45                    | B1T     | Bit
+| 3141       | 0x80000c45                    | B1T     | Bit                               |
 | 3276       | 0x80000ccc                    | CCC     | CodeChain                         |
 | 3344       | 0x80000d10                    | PLMC    | Polimec                           |
 | 3333       | 0x80000d05                    | SXP     | Solar                             |


### PR DESCRIPTION
This pull request adds a new entry to SLIP-0044 for the Bit (B1T) cryptocurrency.

- **Symbol**: B1T  
- **Name**: Bit  
- **coin_type**: 3141  
- **Path component (hex)**: 0x80000c45  
- **Derivation path**: m/0'/3'/n'  
- **Project URL**: https://followthebit.org

This registration ensures compatibility with HD wallets and avoids conflicts with existing entries.
