### PR TITLE
Add Luckycoin to SLIP-0044 registry

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -818,7 +818,7 @@ All these constants are used as hardened derivation.
 | 787        | 0x80000313                    | ACA     | Acala                             |
 | 788        | 0x80000314                    | BNC     | Bifrost                           |
 | 789        | 0x80000315                    | TAU     | Lamden                            |
-| 790        | 0x80000316                    |         |
+| 790        | 0x80000316                    | LKY     | Luckycoin                         |
 | 791        | 0x80000317                    |         |
 | 792        | 0x80000318                    |         |
 | 793        | 0x80000319                    |         |


### PR DESCRIPTION
This PR adds Luckycoin (symbol: LKY) to the SLIP-0044 registry.

- **Coin name**: Luckycoin  
- **Symbol**: LKY  
- **Coin type**: `790`  
- **Hex value**: `0x80000316`  
- **Base58 address prefix**: 47 (addresses start with 'L' or 'M')  
- **Standard derivation path**: m/44'/790'/0'/0/0  
- **Reference URL**: https://luckycoinfoundation.org / https://github.com/LuckyCoinProj

Let me know if any changes are required. Thanks!
