### PR TITLE
Add LTO Network to SLIP-0044 (742)

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -770,7 +770,7 @@ All these constants are used as hardened derivation.
 | 739        | 0x800002e3                    | DPC     | Dpowcoin (DualPowCoin)            |
 | 740        | 0x800002e4                    | MDC     | MyDataCoin                        |
 | 741        | 0x800002e5                    | RIV     | Rigvid                            |
-| 742        | 0x800002e6                    |         |
+| 742        | 0x800002e6                    | LTO     | LTO Network                       |
 | 743        | 0x800002e7                    |         |
 | 744        | 0x800002e8                    | DUSK    | Dusk                              |
 | 745        | 0x800002e9                    |         |


### PR DESCRIPTION
## Project details

- **Name**: LTO Network
- **Symbol**: LTO
- **Website**: https://ltonetwork.com
- **Block explorer**: https://explorer.lto.network
- **GitHub**: https://github.com/ltonetwork
- **Chain ID format**: Base58-encoded addresses
- **Mainnet launch**: January 2019

## Coin type assignment

- **Requested coin type**: `742`
- **Purpose**: To define a dedicated derivation path for deterministic wallets using BIP44
- **Current workaround**: LTO Network currently uses Cosmos’ coin type `118`

## Justification

LTO Network is a fully independent Layer-1 blockchain that has been live since 2019. It's unrelated to Cosmos. It has:

- A native token (LTO) listed on major exchanges (e.g. Binance, Kucoin, Bitvavo)
- Unique public-private architecture for identity anchoring and verifiable credentials
- Usage across real-world compliance, tokenization, and workflow automation
- Active open-source development and infrastructure (nodes, wallets, explorers)

A dedicated BIP44 coin type ensures:
- Standard-compliant HD wallet generation
- Improved interoperability across hardware/software wallets
- Clear separation from Cosmos-based ecosystems