### PR TITLE
Add DogecoinEV (DEV) to SLIP-0044

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1119,6 +1119,7 @@ All these constants are used as hardened derivation.
 | 1951       | 0x8000079f                    | ESA     | Esa                               |
 | 1952       | 0x800007a0                    | ESC     | EsaCoin                           |
 | 1955       | 0x800007a3                    | XX      | xx coin                           |
+| 1969       | 0x800007b1                    | DEV     | DogecoinEV                        |
 | 1977       | 0x800007b9                    | XMX     | Xuma                              |
 | 1984       | 0x800007c0                    | TRTL    | TurtleCoin                        |
 | 1985       | 0x800007c1                    | SLRT    | Solarti Chain                     |


### PR DESCRIPTION
Registers DogecoinEV with coin type 1969 and symbol DEV in the SLIP-0044 registry for BIP-0044 hierarchical deterministic wallets.
Changes:

Added coin type 1969 for DogecoinEV
Symbol: DEV
Hex path component: 0x800007b1