### PR TITLE
Add DogecoinEV (DEV) to SLIP-0044

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1084,6 +1084,7 @@ All these constants are used as hardened derivation.
 | 1348       | 0x80000544                    | ISLM    | IslamicCoin                       |
 | 1397       | 0x80000575                    | HYC     | Hycon                             |
 | 1410       | 0x80000582                    | TENTSLP | TENT Simple Ledger Protocol       |
+| 1420       | 0x8000058c                    | DEV     | DogecoinEV                        |
 | 1510       | 0x800005e6                    | XSC     | XT Smart Chain                    |
 | 1512       | 0x800005e8                    | AAC     | Double-A Chain                    |
 | 1524       | 0x800005f4                    |         | Taler                             |

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1135,6 +1135,7 @@ All these constants are used as hardened derivation.
 | 2001       | 0x800007d1                    | MNP     | MNPCoin                           |
 | 2002       | 0x800007d2                    | MLN     | Miraland                          |
 | 2003       | 0x800007d3                    | ISNA    | iSarrana                          |
+| 2013       | 0x800007dd                    | JKC     | Junkcoin                          |
 | 2015       | 0x800007df                    | TEER    | Integritee                        |
 | 2017       | 0x800007e1                    | KIN     | Kin                               |
 | 2018       | 0x800007e2                    | EOSC    | EOSClassic                        |

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1137,6 +1137,7 @@ All these constants are used as hardened derivation.
 | 2001       | 0x800007d1                    | MNP     | MNPCoin                           |
 | 2002       | 0x800007d2                    | MLN     | Miraland                          |
 | 2003       | 0x800007d3                    | ISNA    | iSarrana                          |
+| 2010       | 0x800007da                    | XBT     | Bitcoin Classic                   |
 | 2013       | 0x800007dd                    | JKC     | Junkcoin                          |
 | 2015       | 0x800007df                    | TEER    | Integritee                        |
 | 2017       | 0x800007e1                    | KIN     | Kin                               |


### PR DESCRIPTION
## Add DogecoinEV (DEV) and Bitcoin Classic (XBT) to SLIP-0044

Registers DogecoinEV with coin type **1420** and symbol **DEV**.

**Changes:**
- Added coin type 1420 for DogecoinEV
- Symbol: DEV
- Hex path component: 0x8000058c

- Added coin type 2010 for Bitcoin Classic
- Symbol: XBT
- Hex path component: 0x800007da

**DogecoinEV Project Details:**
- Website: https://dogecoinev.com/
- Telegram: https://t.me/DEVOFFICIALTG
- Algorithm: Scrypt PoW

**Table Entry:**
| 1420       | 0x8000058c                    | DEV     | DogecoinEV                        |

**Bitcoin Classic  Project Details:**
- Website: https://www.classicxbt.com/
- Telegram: https://t.me/BitcoinClassic2011
- Algorithm: SHA256 PoW

**Table Entry:**
| 2010       | 0x800007da                    | XBT     | Bitcoin Classic                    |
