### PR TITLE
Add BERA (Berachain) to SLIP-0044

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1247,6 +1247,7 @@ All these constants are used as hardened derivation.
 | 7777       | 0x80001e61                    | BTV     | Bitvote                           |
 | 7779       | 0x80001e63                    | CPV     | Compverse                         |
 | 8000       | 0x80001f40                    | SKY     | Skycoin                           |
+| 8008       | 0x80001f48                    | BERA    | Berachain                         |
 | 8017       | 0x80001f51                    | ISC     | iSunCoin                          |
 | 8080       | 0x80001f90                    |         | DSRV                              |
 | 8181       | 0x80001ff5                    | BOC     | BeOne Chain                       |


### PR DESCRIPTION
Registers coin type `8008` for BERA.

https://docs.berachain.com/