### PR TITLE
slip-0021: Specify encoding of integer labels

### DIFF
--- a/slip-0021.md
+++ b/slip-0021.md
@@ -31,7 +31,7 @@ The master node is used to derive child nodes, each of which can in turn be used
 
 ## Child node derivation
 
-The child nodes of a parent node *N* are identified by a variable-length byte string called a *label*. The labels of all nodes which are derived from the master node, i.e., the first-level labels, MUST identify the purpose of the subordinate nodes. The purpose determines the further structure beneath the node. This label must be sufficiently unique to avoid collisions between applications. Examples include the ASCII encoding of the strings "BIP-9999", "SLIP-9999" or "FIDO2 Trezor Credential ID".
+The child nodes of a parent node *N* are identified by a variable-length byte string called a *label*. When an integer value is used as a label, it SHOULD be ASCII-encoded as a decimal integer in the fewest possible number of characters. The labels of all nodes which are derived from the master node, i.e., the first-level labels, MUST identify the purpose of the subordinate nodes. The purpose determines the further structure beneath the node. This label must be sufficiently unique to avoid collisions between applications. Examples include the ASCII encoding of the strings "BIP-9999", "SLIP-9999" or "FIDO2 Trezor Credential ID".
 
 The derivation function is defined as:
 


### PR DESCRIPTION
Specify the encoding of integer labels: ASCII encoding as a decimal integer in the fewest possible number of characters.