### PR TITLE
Add Virel Protocol to SLIP-0044 list

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1229,6 +1229,7 @@ All these constants are used as hardened derivation.
 | 6144       | 0x80001800                    | DTS     | Datos                             |
 | 6174       | 0x8000181e                    | MOI     | My Own Internet                   |
 | 6278       | 0x80001886                    | STEAMX  | Rails Network Mainnet             |
+| 6310       | 0x800018a6                    | VRL     | Virel Protocol                    |
 | 6532       | 0x80001984                    | UM      | Penumbra                          |
 | 6599       | 0x800019c7                    | RSC     | Royal Sports City                 |
 | 6666       | 0x80001a0a                    | BPA     | Bitcoin Pizza                     |


### PR DESCRIPTION
This PR adds Virel Protocol (https://virel.org/) to the SLIP-0044 list.