### PR TITLE
Add ZERA (ZRA) to SLIP-0044 coin type registry

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1416,6 +1416,7 @@ All these constants are used as hardened derivation.
 | 1179993451 | 0xc655456b                    | RWA     | Asset Chain                       |
 | 1179993461 | 0xc6554575                    | HXC     | HuaXia Chain                      |
 | 1179993471 | 0xc655457f                    | AME     | AME Chain                         | 
+| TBD    | TBD        | ZRA | ZERA |
 
 Coin types will be added only if there is a wallet implementing BIP-0044 for desired coin.
 


### PR DESCRIPTION
### Request: SLIP-0044 coin_type for ZERA

**Coin name**: ZERA  
**Symbol**: ZRA  
**Short description**:  ZERA is a fully decentralized general-purpose Layer 1 blockchain that emphasizes governance capabilities.

**Website**:  
There is no official or central website or team. The chain is community-governed. PR requester website: https://zeravision.ca

**GitHub Repositories** (Community Maintained):  
- Network: https://github.com/ZeraVision/zera-network-validator  
- Go SDK: https://github.com/ZeraVision/zera-go-sdk  

**Whitepaper (most widely accepted)**:  
https://explorer.zera.vision/transactions/f4ad9df159b45bae797cc0eb198ff7969cb9383701198d5b34297bff5b689838/memo  

**Explorer** (Non Official, Private Company):  
https://explorer.zera.vision/

**Contact Email** (PR requester):  
support@zeravision.ca

---

### Derivation Path & Key Type

ZERA uses BIP-44-compatible hierarchical deterministic (HD) wallets.  
It supports multiple key types under a unified coin_type:

- `m/44'/<assigned_coin_type>'/0'/0/0` → `ed25519` (ZRA-A)  
- `m/44'/<assigned_coin_type>'/1'/0/0` → `ed448` (ZRA-B)

These are used to differentiate native asset variants under one HD seed while maintaining compatibility with existing standards and libraries.

---

### Request

We request assignment of a SLIP-0044 `coin_type` for the ZERA Network.
