### PR TITLE
Add DiminutiveCoin (DIMI) to SLIP-0044 registry

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -773,7 +773,7 @@ All these constants are used as hardened derivation.
 | 742        | 0x800002e6                    | LTO     | LTO Network                       |
 | 743        | 0x800002e7                    | LKY     | LuckyCoin                         |
 | 744        | 0x800002e8                    | DUSK    | Dusk                              |
-| 745        | 0x800002e9                    |         |
+| 745        | 0x800002e9                    | DIMI    | DiminutiveCoin                    |
 | 746        | 0x800002ea                    |         |
 | 747        | 0x800002eb                    | CFG     | Centrifuge                        |
 | 748        | 0x800002ec                    |         |


### PR DESCRIPTION
This PR registers DiminutiveCoin (DIMI) for HD wallet derivation under SLIP-0044.

- Name: DiminutiveCoin
- Symbol: DIMI
- Purpose: Used in BIP-44 compatible wallets to derive keys and addresses
- Suggested Coin type: 745
- Suggested Path component ( coin_type' ): 0x800002e9
- Project URL: https://github.com/MadCatMining/DiminutiveCoin