### PR TITLE
Add Palladium (PLM) coin type 746

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -774,7 +774,7 @@ All these constants are used as hardened derivation.
 | 743        | 0x800002e7                    | LKY     | LuckyCoin                         |
 | 744        | 0x800002e8                    | DUSK    | Dusk                              |
 | 745        | 0x800002e9                    | DIMI    | DiminutiveCoin                    |
-| 746        | 0x800002ea                    |         |
+| 746        | 0x800002ea                    | PLM     | Palladium
 | 747        | 0x800002eb                    | CFG     | Centrifuge                        |
 | 748        | 0x800002ec                    |         |
 | 749        | 0x800002ed                    |         |


### PR DESCRIPTION
This PR adds support for the Palladium (PLM) cryptocurrency in SLIP-0044.

- Coin type: 746
- Derivation path: m/84'/746'/0'/0
- Based on Bitcoin fork, using SegWit bech32 addresses with HRP "plm".
- Compatible with BIP84 standard.

Please review and consider merging. Thank you.