### PR TITLE
Add Dinero (DNR) - coin type 1447

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1087,6 +1087,7 @@ All these constants are used as hardened derivation.
 | 1397       | 0x80000575                    | HYC     | Hycon                             |
 | 1410       | 0x80000582                    | TENTSLP | TENT Simple Ledger Protocol       |
 | 1420       | 0x8000058c                    | DEV     | DogecoinEV                        |
+| 1447       | 0x800005a7                    | DNR     | Dinero                        |
 | 1510       | 0x800005e6                    | XSC     | XT Smart Chain                    |
 | 1512       | 0x800005e8                    | AAC     | Double-A Chain                    |
 | 1524       | 0x800005f4                    |         | Taler                             |


### PR DESCRIPTION
# Add Dinero (DNR)

## Coin Information
- **Coin Type:** 1447 (0x800005a7)
- **Symbol:** DNR
- **Name:** Dinero
- **Repository:** https://github.com/Trucker2827/Dinero-Coin

## Technical Details
- **Standard:** BIP84 (Native SegWit)
- **Derivation Path:** m/84'/1447'/0'/0/x
- **Address Type:** P2WPKH (Bech32)
- **Bech32 HRP:** dnr
- **Example Address:** dnr1qw508d6qejxtdg4y5r3zarvary0c5xw7kxzy6k3

## Blockchain Specifications
- **Algorithm:** SHA-256 (two-phase mining)
- **Block Time:** 5 minutes
- **Max Supply:** 99,000,000 DNR
- **Precision:** 8 decimals
- **Launch:** 2025 (Mainnet)

## Verification
Coin type 1447 verified as available in the SLIP-44 registry.

## Project Status
- Active development
- Testnet operational
- Mainnet launching 2025
- Open source (MIT License)
- BIP39/BIP32/BIP84 compliant

## Maintainer
- GitHub: @Trucker2827
- Project: https://github.com/Trucker2827/Dinero-Coin

Thank you for reviewing this registration request!