### PR TITLE
Add DOL coin type to slip-0044.md

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1440,6 +1440,7 @@ All these constants are used as hardened derivation.
 | 1179993461 | 0xc6554575                    | HXC     | HuaXia Chain                      |
 | 1179993471 | 0xc655457f                    | AME     | AME Chain                         |
 | 1869902945 | 0xef747461                    | ATTO    | Atto                              |
+| 1869902946 |                               | DOL     | DOL                               |
 
 Coin types will be added only if there is a wallet implementing BIP-0044 for desired coin.
 


### PR DESCRIPTION
Requesting SLIP-0044 coin type for:
- Name: Dolphinet
- Symbol: DOL
- Website/Docs: https://chain.dolphinode.world
- Network type: EVM chain
- Chain IDs: mainnet 1520, testnet 1519