### PR TITLE
Update BlueChip abbreviation from 'bcp' to 'bluechip'

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -64,7 +64,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | Blackcoin                | `blk`         | `tblk`   | `blrt`      |
 | Blacknet                 | `blacknet`    |          | `rblacknet` |
 | BlockX                   | `blockx`      |          |             |
-| BlueChip                 | `bcp`         |          |             |
+| BlueChip                 | `bluechip`    |          |             |
 | Bluzelle                 | `bluzelle`    |          |             |
 | bostrom                  | `bostrom`     |          |             |
 | Bouachain                | `bouachain`   |          |             |


### PR DESCRIPTION
The BlueChip chain is being relaunched with a new architecture. The previous prefix `bcp` is no longer in use. The new prefix `bluechip` better reflects the project branding and improves address readability.