### PR TITLE
UPDATE Aureuscoin

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1310,6 +1310,7 @@ All these constants are used as hardened derivation.
 | 11111      | 0x80002b67                    | ESS     | Essentia One                      |
 | 11742      | 0x80002dde                    | VARCH   | InvArch                           |
 | 11743      | 0x80002ddf                    | TNKR    | Tinkernet                         |
+| 11995      | 0x80002edb                    | AUR     | Aureus                            |
 | 12345      | 0x80003039                    | IPOS    | IPOS                              |
 | 12586      | 0x8000312a                    | MINA    | Mina                              |
 | 12850      | 0x80003232                    | ANLOG   | Analog Timechain                  |

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1310,7 +1310,7 @@ All these constants are used as hardened derivation.
 | 11111      | 0x80002b67                    | ESS     | Essentia One                      |
 | 11742      | 0x80002dde                    | VARCH   | InvArch                           |
 | 11743      | 0x80002ddf                    | TNKR    | Tinkernet                         |
-| 11995      | 0x80002edb                    | AUR     | Aureus                            |
+| 11995      | 0x80002edb                    | AURE    | Aureus                           |
 | 12345      | 0x80003039                    | IPOS    | IPOS                              |
 | 12586      | 0x8000312a                    | MINA    | Mina                              |
 | 12850      | 0x80003232                    | ANLOG   | Analog Timechain                  |


### PR DESCRIPTION
I would like to update the ticker for Aureuscoin to AURE in this registration.

Technical Note: While the internal codebase and constants still use the legacy symbol AUR, we have officially transitioned the market identifier and community ticker to AURE to prevent naming collisions with Auroracoin. All major exchanges (AnonEx, KomodoDEX), mining pools, and explorers now recognize the asset as AURE.

For the sake of consistency in hardware wallets and user interfaces, AURE is the correct public-facing symbol.