### PR TITLE
Add Locus Chain entry to slip-0044.md

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1376,6 +1376,7 @@ All these constants are used as hardened derivation.
 | 130822     | 0x8001ff06                    | WBT     | WhiteBIT Coin                     |
 | 161803     | 0x8002780b                    | APTA    | Bloqs4Good                        |
 | 189189     | 0x8002e305                    | QUAN    | Quantus Network                   |
+| 190301     | 0x8002E75D                    | LOCUS   | Locus Chain                       | 
 | 200625     | 0x80030fb1                    | AKA     | Akroma                            |
 | 200901     | 0x800310c5                    | BTR     | Bitlayer                          |
 | 224433     | 0x80036cb1                    | CONET   | CONET Holesky Network             |

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1376,7 +1376,7 @@ All these constants are used as hardened derivation.
 | 130822     | 0x8001ff06                    | WBT     | WhiteBIT Coin                     |
 | 161803     | 0x8002780b                    | APTA    | Bloqs4Good                        |
 | 189189     | 0x8002e305                    | QUAN    | Quantus Network                   |
-| 190301     | 0x8002E75D                    | LOCUS   | Locus Chain                       | 
+| 190301     | 0x8002e75d                    | LOCUS   | Locus Chain                       | 
 | 200625     | 0x80030fb1                    | AKA     | Akroma                            |
 | 200901     | 0x800310c5                    | BTR     | Bitlayer                          |
 | 224433     | 0x80036cb1                    | CONET   | CONET Holesky Network             |


### PR DESCRIPTION
This PR proposes adding Locus Chain (LOCUS) to SLIP-0044.

Coin name: Locus Chain
Ticker: LOCUS
Proposed coin type: 190301 (0x8002E75D hardened)

Proposed BIP44 path:

m/4400'/190301'/account'/change/address_index

Project links:
Project website : https://www.locuschain.com/
Wallet install guide : https://docs.testnet2.locuschain.com/docs/guides/wallet/wallet-install
Testnet Explorer : https://explorer.testnet2.locuschain.com/

Coinmarketcap : 
https://coinmarketcap.com/ko/currencies/locus-chain/