### PR TITLE
Add RXB - Record X-core Blockchain (coin type 8327)

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1166,6 +1166,7 @@ All these constants are used as hardened derivation.
 | 2025       | 0x800007e9                    | ROCK    | Zenrock Labs                      |
 | 2026       | 0x800007ea                    | ASTRON  | ASTRON Token                      |
 | 2027       | 0x800007eb                    | UNC     | UniCash                           |
+| 8327       | 0x80002087                    | RXB     | Record X-core Blockchain          |
 | 2046       | 0x800007fe                    | ANY     | Any                               |
 | 2048       | 0x80000800                    | MCASH   | MCashChain                        |
 | 2049       | 0x80000801                    | TRUE    | TrueChain                         |


### PR DESCRIPTION
Adding coin type for RXB (Record X-core Blockchain).

- Coin type: 8327
- Path component: 0x80002087
- Symbol: RXB
- Name: Record X-core Blockchain
- Network: Bitcoin-hardfork PoW blockchain
- P2P Port: 8327
- Website/Repository: https://github.com/Heiwabitnull/rxb-core