### PR TITLE
Add RXB - Record X-core Blockchain HD version bytes (rxpu/rxpr)

### DIFF
--- a/slip-0132.md
+++ b/slip-0132.md
@@ -60,9 +60,9 @@ Nexa                                      | `0x42696720` - `xpub` | `0x426c6b73`
 Nexa Testnet                              | `0x043587cf` - `xpub` | `0x04358394` - `xprv` | P2PKT or P2PKH or P2SH           | m/44'/1'    |
 Vertcoin                                  | `0x0488b21e` - `vtcp` | `0x0488ade4` - `vtcv` | P2PKH or P2SH                    | m/44'/28'   |
 Polis                                     | `0x03e25d7e` - `ppub` | `0x03e25945` - `pprv` | P2PKH                            | m/44'/1997' |
+Record X-core Blockchain                 | `0x040ec961` - `rxpu` | `0x040ec94c` - `rxpr` | P2PKH or P2SH                    | m/44'/8327' |
 Syscoin                                   | `0x04b24746` - `zpub` | `0x04b2430c` - `zprv` | P2WPKH                           | m/84'/57'   |
 Syscoin                                   | `0x02aa7ed3` - `Zpub` | `0x02aa7a99` - `Zprv` | Multi-signature P2WSH            | -           |
-Record X-core Blockchain                 | `0x040ec961` - `rxpu` | `0x040ec94c` - `rxpr` | P2PKH or P2SH                    | m/44'/8327' |
 
 ## Bitcoin Test Vectors
 

--- a/slip-0132.md
+++ b/slip-0132.md
@@ -62,6 +62,7 @@ Vertcoin                                  | `0x0488b21e` - `vtcp` | `0x0488ade4`
 Polis                                     | `0x03e25d7e` - `ppub` | `0x03e25945` - `pprv` | P2PKH                            | m/44'/1997' |
 Syscoin                                   | `0x04b24746` - `zpub` | `0x04b2430c` - `zprv` | P2WPKH                           | m/84'/57'   |
 Syscoin                                   | `0x02aa7ed3` - `Zpub` | `0x02aa7a99` - `Zprv` | Multi-signature P2WSH            | -           |
+Record X-core Blockchain                 | `0x040ec961` - `rxpu` | `0x040ec94c` - `rxpr` | P2PKH or P2SH                    | m/44'/8327' |
 
 ## Bitcoin Test Vectors
 


### PR DESCRIPTION
Adding HD version bytes for RXB (Record X-core Blockchain).

- Coin: Record X-core Blockchain
- Public Key:  0x040ec961 - rxpu  (P2PKH or P2SH)
- Private Key: 0x040ec94c - rxpr  (P2PKH or P2SH)
- BIP32 Path:  m/44'/8327'
- Network: Bitcoin-Hardfork PoW blockchain, Tor-only
- SLIP-0044 PR: satoshilabs/slips#1988
- Repository: https://github.com/Heiwabitnull/rxb-core