### PR TITLE
Add AOXCHAIN coin type (2626)

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1188,6 +1188,7 @@ All these constants are used as hardened derivation.
 | 2457       | 0x80000999                    | HYPE    | Hyperliquid                       |
 | 2500       | 0x800009c4                    | NEXI    | Nexi                              |
 | 2570       | 0x80000a0a                    | AOA     | Aurora                            |
+| 2626       | 0x80000a42                    | AOXC    | AOXCHAIN                          |
 | 2686       | 0x80000a7e                    | AIPG    | AIPowerGrid                       |
 | 2718       | 0x80000a9e                    | NAS     | Nebulas                           |
 | 2809       | 0x80000af9                    | LAN     | Lanify                            |


### PR DESCRIPTION
Add SLIP-0044 coin type for AOXCHAIN (AOXC).

Coin type: 2626
Hardened index: 0x80000a42
Repository: https://github.com/aoxc/aoxchain