### PR TITLE
slip-0173: Add Avian Network

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -41,6 +41,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | Athena                   | `ath`         | `atest`  |             |
 | AtomOne                  | `atone`       |          |             |
 | Aura Network             | `aura`        |          |             |
+| Avian Network            | `avn`         | `tavn`   | `avnrt`     |
 | Axelar                   | `axelar`      |          |             |
 | Axone                    | `axone`       |          |             |
 | Babylon                  | `bbn`         |          |             |


### PR DESCRIPTION
Register human-readable parts for Avian Network:

- Mainnet: `avn`
- Testnet: `tavn`
- Regtest: `avnrt`