### PR TITLE
Add GAEL (Gaelium) coin type 1313

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1083,6 +1083,7 @@ All these constants are used as hardened derivation.
 | 1298       | 0x80000512                    | WPC     | Wpc                               |
 | 1308       | 0x8000051c                    | WEI     | WEI                               |
 | 1312       | 0x80000520                    | BITS    | Entropy                           |
+| 1313       | 0x80000521                    | GAEL    | Gaelium                           |
 | 1337       | 0x80000539                    | DFC     | Defcoin                           |
 | 1338       | 0x8000053a                    | IRON    | Iron Fish                         |
 | 1339       | 0x8000053b                    | WNSD    | Winsdet                           |


### PR DESCRIPTION
Add Gaelium (GAEL) - coin type 1313 (0x80000521)

- Website: https://gaelium.io
- GitHub: https://github.com/GaeliumCore
- Algorithm: KAWPOW (Ravencoin fork)
- Wallet: Gaelium Desktop Wallet v1.0.0 implements BIP-44 Windows (installer + portable), Linux (AppImage + deb + rpm), Mac (dmg + zip)
- Explorer: https://explorer.gaelium.io