### PR TITLE
slip-0044: add Unicash (UNC) coin type 2027

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1162,6 +1162,7 @@ All these constants are used as hardened derivation.
 | 2024       | 0x800007e8                    | USBC    | Universal Ledger USBC             |
 | 2025       | 0x800007e9                    | ROCK    | Zenrock Labs                      |
 | 2026       | 0x800007ea                    | ASTRON  | ASTRON Token                      |
+| 2027       | 0x800007eb                    | UNC     | UniCash                           |
 | 2046       | 0x800007fe                    | ANY     | Any                               |
 | 2048       | 0x80000800                    | MCASH   | MCashChain                        |
 | 2049       | 0x80000801                    | TRUE    | TrueChain                         |


### PR DESCRIPTION
Add Unicash (UNC) as coin type 2027.

Coin: Unicash
Symbol: UNC
Coin type: 2027
Path component:  0x800007eb

Homepage: https://unicash.network