### PR TITLE
slip-0044: add Crypterra (CTA) coin type 1869902946

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1451,6 +1451,7 @@ All these constants are used as hardened derivation.
 | 1179993461 | 0xc6554575                    | HXC     | HuaXia Chain                      |
 | 1179993471 | 0xc655457f                    | AME     | AME Chain                         |
 | 1869902945 | 0xef747461                    | ATTO    | Atto                              |
+| 1869902946 | 0xef747462                    | CTA     | Crypterra                         |
 
 Coin types will be added only if there is a wallet implementing BIP-0044 for desired coin.
 


### PR DESCRIPTION
## Adding Crypterra (CTA) to SLIP-0044

This PR registers Crypterra (CTA) as coin type **1869902946** (path component `0xef747462`) in the SLIP-0044 standard.

### Coin Details
- **Name:** Crypterra
- **Symbol:** CTA
- **Algorithm:** SHA-256 Proof-of-Work
- **Total Supply:** 21,000,000 CTA
- **Block Time:** 60 seconds
- **Website:** https://crypterra.cc
- **GitHub:** https://github.com/Heliosfrontier/crypterra

Crypterra is a fair-launch SHA-256 PoW cryptocurrency with a 21 million coin hard cap, mirroring Bitcoin's scarcity model. It includes a smart contract layer supporting CTA-20 tokens, escrow contracts, and timelock vaults. The wallet implementation uses BIP-39 mnemonic phrases and BIP-44 HD derivation, making this SLIP-0044 registration the natural next step for multi-wallet compatibility.