### PR TITLE
Add LitecoinII (LC2) coin type 2102

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1168,6 +1168,7 @@ All these constants are used as hardened derivation.
 | 2050       | 0x80000802                    | MOVO    | Movo Smart Chain                  |
 | 2086       | 0x80000826                    | KILT    | KILT Spiritnet                    |
 | 2091       | 0x8000082b                    | FRQCY   | Frequency                         |
+| 2102       | 0x80000836                    | LC2     | LitecoinII                        |
 | 2109       | 0x8000083d                    | SAMA    | Exosama Network                   |
 | 2112       | 0x80000840                    | IoTE    | IoTE                              |
 | 2121       | 0x80000849                    | CBTC    | Coordinate BTC (Anduro)           |


### PR DESCRIPTION
This Pull Request adds LitecoinII (LC2) to SLIP-0044.

- Coin type: 2102
- Symbol: LC2
- Name: LitecoinII

LitecoinII is a Litecoin-derived cryptocurrency that uses SegWit bech32 addresses with HRP "lc2".

Source code: https://github.com/litecoinII-project/litecoinII

Thank you.