### PR TITLE
Register SLIP-0044 index for BitcoinGold (BTGS)

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1315,6 +1315,7 @@ All these constants are used as hardened derivation.
 | 11742      | 0x80002dde                    | VARCH   | InvArch                           |
 | 11743      | 0x80002ddf                    | TNKR    | Tinkernet                         |
 | 11995      | 0x80002edb                    | AURE    | Aureus                            |
+| 18888      | 0x800049c8                    | BTGS    | BitcoinGold                       |
 | 12345      | 0x80003039                    | IPOS    | IPOS                              |
 | 12586      | 0x8000312a                    | MINA    | Mina                              |
 | 12850      | 0x80003232                    | ANLOG   | Analog Timechain                  |


### PR DESCRIPTION
### Summary
This PR registers a new coin type index for **BitcoinGold (BTGS)** in accordance with the SLIP-0044 standard.

### Details
- **Coin Name:** BitcoinGold
- **Symbol:** BTGS
- **Index:** 18888 (0x800049c8)
- **Algorithm:** SHA-256
- **Project Website:** https://bitcoingold.site
- - **Project Explore:** https://explore.bitcoingold.site


The index 18888 has been selected to avoid any current conflicts in the registry and will be used for HD wallet derivation paths (m/44'/18888'/0').

Thank you for maintaining the registry.