### PR TITLE
Add Geeq Chain entry to slip-0044.md

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1047,7 +1047,7 @@ All these constants are used as hardened derivation.
 | 1016       | 0x800003f8                    | ---     | reserved                          |
 | 1017       | 0x800003f9                    | ZTC     | Zenchain                          |
 | 1018       | 0x800003fa                    | ZANO    | Zano                              |
-| 1019       | 0x800003fb                    | GEEQ    | Geeq Chain                        |
+| 1019       | 0x800003fb                    | GEEQ    | Geeq                              |
 | 1020       | 0x800003fc                    | EVC     | Evrice                            |
 | 1021       | 0x800003fd                    | PKOIN   | Pocketcoin                        |
 | 1022       | 0x800003fe                    | XRD     | Radix DLT                         |

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1047,6 +1047,7 @@ All these constants are used as hardened derivation.
 | 1016       | 0x800003f8                    | ---     | reserved                          |
 | 1017       | 0x800003f9                    | ZTC     | Zenchain                          |
 | 1018       | 0x800003fa                    | ZANO    | Zano                              |
+| 1019       | 0x800003fb                    | GEEQ    | Geeq Chain                        |
 | 1020       | 0x800003fc                    | EVC     | Evrice                            |
 | 1021       | 0x800003fd                    | PKOIN   | Pocketcoin                        |
 | 1022       | 0x800003fe                    | XRD     | Radix DLT                         |


### PR DESCRIPTION
Geeq Chain (https://geeq.io/) is an upcoming public blockchain currently under active development. We intend to use a deterministic BIP-0044 derivation path for all wallets, SDKs, and ecosystem tools.

Although the mainnet is not launched yet, the BIP44 coin_type is required at this stage because: • Wallet development has already begun.
• Testnet key generation and account architecture are based on BIP-0044, SLIP-0010 standards. • A fixed coin_type is needed to avoid future conflicts and ensure compatibility before the mainnet launch.

Requesting this SLIP-0044 registration early allows us to finalize the wallet, SDK, and related ecosystem tools following the correct BIP44 path from the beginning without migration issues.

Proposed BIP44 path:
m/geeq_record_type'/1019'/account'/change'/address_index'

Project website : https://geeq.io/

Coinmarketcap :
https://coinmarketcap.com/currencies/geeq/