### PR TITLE
rename: Coreum to TX in slip-0044 and slip-0173

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1018,7 +1018,7 @@ All these constants are used as hardened derivation.
 | 987        | 0x800003db                    | VCG     | VipCoin                           |
 | 988        | 0x800003dc                    | XAZAB   | Xazab core                        |
 | 989        | 0x800003dd                    | AIOZ    | AIOZ                              |
-| 990        | 0x800003de                    | CORE    | Coreum                            |
+| 990        | 0x800003de                    | CORE    | TX                                |
 | 991        | 0x800003df                    | PEC     | Phoenix                           |
 | 992        | 0x800003e0                    | UNT     | Unit                              |
 | 993        | 0x800003e1                    | XRB     | X Currency                        |

--- a/slip-0173.md
+++ b/slip-0173.md
@@ -85,7 +85,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | Commercio                | `did:com:`    |          |             |
 | Composable               | `centauri`    |          |             |
 | ConsciousDAO             | `cvn`         |          |             |
-| Coreum                   | `core`        |`testcore`|             |
+| TX                       | `core`        |`testcore`|             |
 | Cosmos Hub               | `cosmos`      |          |             |
 | Coss Chain               | `coss`        | `tcoss`  |             |
 | CPUchain                 | `cpu`         | `tcpu`   | `rcpu`      |


### PR DESCRIPTION
## Description

The main change is renaming the entry previously labeled as "Coreum" to "TX" while retaining the same symbol and encoding identifiers.

**Specification updates:**

* Updated the name for coin type `0x800003de` from "Coreum" to "TX" in `slip-0044.md` to reflect the correct project name.
* Changed the human-readable part registration from "Coreum" to "TX" for the `core` prefix in `slip-0173.md`, maintaining the same Bech32 encoding.