### PR TITLE
SLIP-0044: register coin type 1448 for Dinero v7

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1093,6 +1093,7 @@ All these constants are used as hardened derivation.
 | 1410       | 0x80000582                    | TENTSLP | TENT Simple Ledger Protocol       |
 | 1420       | 0x8000058c                    | DEV     | DogecoinEV                        |
 | 1447       | 0x800005a7                    | DNR     | Dinero                            |
+| 1448       | 0x800005a8                    | DNR7    | Dinero v7                         |
 | 1510       | 0x800005e6                    | XSC     | XT Smart Chain                    |
 | 1512       | 0x800005e8                    | AAC     | Double-A Chain                    |
 | 1524       | 0x800005f4                    |         | Taler                             |

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1093,7 +1093,7 @@ All these constants are used as hardened derivation.
 | 1410       | 0x80000582                    | TENTSLP | TENT Simple Ledger Protocol       |
 | 1420       | 0x8000058c                    | DEV     | DogecoinEV                        |
 | 1447       | 0x800005a7                    | DNR     | Dinero                            |
-| 1448       | 0x800005a8                    | DNR7    | Dinero v7                         |
+| 1448       | 0x800005a8                    | DIN     | Dinero v7                         |
 | 1510       | 0x800005e6                    | XSC     | XT Smart Chain                    |
 | 1512       | 0x800005e8                    | AAC     | Double-A Chain                    |
 | 1524       | 0x800005f4                    |         | Taler                             |


### PR DESCRIPTION
This proposes a new SLIP-44 coin type allocation for Dinero v7:

- `1448` / `0x800005a8`
- symbol: `DIN`
- coin: `Dinero v7`

Rationale:
- Dinero currently uses `1447` for the active v5 chain.
- Dinero v7 is a fresh-genesis successor with a distinct wallet/signature model.
- Using a separate coin type avoids cross-chain key reuse for shared-mnemonic wallets and gives hardware/software wallets a stable derivation-path boundary.

This patch is intentionally minimal and does not attempt to modify the existing historical Dinero rows (`447` and `1447`) in the same change.
