### PR TITLE
slip-0044: add Fistbump (FBC) as coin type 14159

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1330,6 +1330,7 @@ All these constants are used as hardened derivation.
 | 13108      | 0x80003334                    | YCC     | Yuan Chain Coin                   |
 | 13381      | 0x80003445                    | PHX     | Phoenix                           |
 | 14001      | 0x800036b1                    | WAX     | Worldwide Asset Exchange          |
+| 14159      | 0x8000374f                    | FBC     | Fistbump                          |
 | 15845      | 0x80003de5                    | SDGO    | SanDeGo                           |
 | 16181      | 0x80003f35                    | XTX     | Totem Live Network                |
 | 16754      | 0x80004172                    | ARDR    | Ardor                             |


### PR DESCRIPTION
Registering coin type 14159 for Fistbump (FBC)

- Website: https://fistbump.org
- Source: https://github.com/fistbump-org/fbd
