### PR TITLE
slip-0173: add Dash platform entry

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -324,6 +324,7 @@ other entries use Bech32. `[text]` indicates variable content in the human-reada
 |                   | `age-secret-key-`              |
 |                   | `age1[name]`                   |
 |                   | `age-plugin-[name]-`           |
+| Dash (Platform)   | `dash` (m)                     | `tdash` (m)                |                               |
 | Lightning Network | `ln[currency prefix + amount]` |
 | Zcash             | `zs`                           | `ztestsapling`             | `zregtestsapling`             |
 |                   | `zivks`                        | `zivktestsapling`          | `zivkregtestsapling`          |


### PR DESCRIPTION
Dash is now using bech32m addresses as defined in [DIP-0018](https://github.com/dashpay/dips/blob/master/dip-0018.md) for [Dash Platform](https://docs.dash.org/projects/platform/en/stable/docs/intro/what-is-dash-platform.html). This pull requests adds an entry for the `dash`/`tdash` HRPs that we're using.