### PR TITLE
Register SLIP-0044 index for BitAiir (AIIR)

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1287,6 +1287,7 @@ All these constants are used as hardened derivation.
 | 8680       | 0x800021e8                    | PLMNT   | Planetmint                        |
 | 8732       | 0x8000221c                    | BLN     | Bullions                          |
 | 8738       | 0x80002222                    | ALPH    | Alph Network                      |
+| 8800       | 0x80002260                    | AIIR    | BitAiir                           |
 | 8866       | 0x800022a2                    | GGX     | Golden Gate                       |
 | 8886       | 0x800022b6                    | GGXT    | Golden Gate Sydney                |
 | 8887       | 0x800022b7                    | KTA     | Keeta                             |


### PR DESCRIPTION
### Summary
This PR registers a new coin type index for **BitAiir (AIIR)** in
accordance with the SLIP-0044 standard.

### Details
- **Coin Name:** BitAiir
- **Symbol:** AIIR
- **Index:** 8800 (0x80002260)
- **Algorithm:** Proof of Aiir (SHA-256d wrapped in Argon2id 64 MiB,
  memory-hard anti-ASIC)
- **Project repository:** https://github.com/bitaiir/bitaiir
- **Protocol specification:** https://github.com/bitaiir/bitaiir/blob/master/docs/protocol.md

### Status
BitAiir is a from-scratch cryptocurrency in Rust focused on
zero-fee P2P payments and on-chain commerce primitives (escrow N-of-M
and human-readable aliases at the consensus level). The wallet, P2P,
RPC, and consensus layers are already functional on testnet, with the
v0.1.0 mainnet release in active preparation.

### BIP-0044 path
- Mainnet: `m/44'/8800'/0'/0/<index>`
- Testnet: `m/44'/1'/0'/0/<index>` (using the SLIP-0044 universal
  testnet slot, so hardware wallets in testnet mode produce matching
  addresses without custom firmware)

The original placeholder `8888` collided with Super Bitcoin (SBTC),
so we picked the next free slot `8800`. Both the index and the
ticker symbol `AIIR` are unused in the current registry, and the
chosen value is already wired into the codebase
(`crates/bitaiir-types/src/network.rs`,
`crates/bitaiir-crypto/src/hd.rs`, and `docs/protocol.md` §14.1) so
it will not change after registration.

Thank you for maintaining the registry.