### PR TITLE
Add Solen Blockchain (SOLEN) coin type 20260424

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1448,6 +1448,7 @@ All these constants are used as hardened derivation.
 | 11259375   | 0x80abcdef                    | LBR     | 0L                                |
 | 20230101   | 0x8134afd5                    | ROH     | Rooch                             |
 | 20240430   | 0x8134d82e                    | NLK     | NuLinkCoin                        |
+| 20260424   | 0x81352648                    | SOLEN   | Solen                              |
 | 35600000   | 0x821f3680                    | AXX     | AtlasX Chain                      |
 | 240079435  | 0x8e4f524b                    | ZORK    | Zork Network                      |
 | 268435779  | 0x90000143                    | MON     | Monad                             |


### PR DESCRIPTION
Adds a SLIP-0044 entry for Solen Blockchain.

**Symbol:** SOLEN
**Coin type:** 20260424 (`0x81352648`) — encodes Solen's mainnet launch date (2026-04-24)
**Mainnet:** live since 2026-04-24
**Website:** https://solenchain.io
**Explorer:** https://solenscan.io
**Repo:** https://github.com/Solen-Blockchain/solen

Solen is a Layer 1 blockchain with BFT proof-of-stake consensus and a
WASM execution layer. Account IDs are 32-byte ed25519 public keys
displayed in Base58. The wallet implementation will use BIP-39 mnemonics
and SLIP-0010 ed25519 derivation at path `m/44'/20260424'/<account>'/0'`,
matching the Solana/Phantom convention for ed25519 chains.

Wallet under development; this registration unblocks deterministic
derivation across Solen's first-party wallet, hardware wallets, and
third-party integrations (Trust Wallet, Ledger).
