### PR TITLE
slip-0173: register HRP md for Mnemonic Descriptor (BIP 388 wallet-policy backup)

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -325,6 +325,7 @@ other entries use Bech32. `[text]` indicates variable content in the human-reada
 |                   | `age1[name]`                   |
 |                   | `age-plugin-[name]-`           |
 | Lightning Network | `ln[currency prefix + amount]` |
+| Mnemonic Descriptor | `md`                         |                            |                               |
 | Zcash             | `zs`                           | `ztestsapling`             | `zregtestsapling`             |
 |                   | `zivks`                        | `zivktestsapling`          | `zivkregtestsapling`          |
 |                   | `zxviews`                      | `zxviewtestsapling`        | `zxviewregtestsapling`        |


### PR DESCRIPTION
Registers the HRP `md` for the Mnemonic Descriptor (MD) format — a steel-engravable backup format for BIP 388 wallet policies. Spec + reference implementation at https://github.com/bg002h/descriptor-mnemonic.

**Format scope**: not a cryptocurrency network. MD encodes wallet-policy templates (BIP 388 grammar with `@i` placeholders) into Bech32 strings prefixed `md1...` for engraving on steel backup plates. The format is recovery-oriented: the engraved card carries the policy structure, not key material; keys remain in BIP 39 seed words.

**HRP collision vet performed prior to selection** (2026-04-27 during the v0.3.0 rename release):
- SLIP-0173 main coin table — clean (closest 2-char HRPs are `mm` Miden, `my` Myriad)
- Lightning Network HRPs (`lnbc`, `lntb`, `lnbcrt`, `lnsb`, `lno`, `lni`, `lnr`) — distinct
- Liquid sidechain (`ex`, `lq`, `el`, `tlq`, `ert`) — distinct
- Codex32 BIP 93 (`ms`) — distinct (and the inspiration for the 2-char HRP style)
- Nostr NIP-19 (`npub`, `nsec`, `note`, etc.) — distinct
- Cosmos chain HRPs — distinct

**Status**: BIP draft is currently *Pre-Draft, AI + reference implementation, awaiting human review*. Latest release: [`md-codec-v0.4.1`](https://github.com/bg002h/descriptor-mnemonic/releases/tag/md-codec-v0.4.1).

Filing this defensive registration to close off future collision risk from independent projects.