### PR TITLE
slip-0173: register HRP mk for Mnemonic Key (BIP 32 xpub backup)

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -325,6 +325,7 @@ other entries use Bech32. `[text]` indicates variable content in the human-reada
 |                   | `age1[name]`                   |
 |                   | `age-plugin-[name]-`           |
 | Lightning Network | `ln[currency prefix + amount]` |
+| Mnemonic Key      | `mk`                           |                            |                               |
 | Zcash             | `zs`                           | `ztestsapling`             | `zregtestsapling`             |
 |                   | `zivks`                        | `zivktestsapling`          | `zivkregtestsapling`          |
 |                   | `zxviews`                      | `zxviewtestsapling`        | `zxviewregtestsapling`        |


### PR DESCRIPTION
Registers the HRP `mk` for the Mnemonic Key (MK) format — a steel-engravable backup format for individual BIP 32 extended public keys (xpubs). Spec + reference implementation at https://github.com/bg002h/mnemonic-key.

**Format scope**: not a cryptocurrency network. MK encodes individual xpubs into Bech32-style strings prefixed `mk1...` for engraving on steel backup plates, designed to engrave alongside the sibling Mnemonic Descriptor (MD, HRP `md`) policy card for foreign-xpub multisig recovery. The engraved card carries one xpub plus declarative metadata (Policy ID stubs, optional master fingerprint, derivation path); keys remain in BIP 39 seed words.

**HRP collision vet performed prior to selection** (2026-04-29, recorded in [`design/AUDIT_hrp_mk_collision.md`](https://github.com/bg002h/mnemonic-key/blob/main/design/AUDIT_hrp_mk_collision.md)):
- SLIP-0173 main coin table — clean (closest 2-char HRPs are `mm` Miden, `my` Myriad; closest 1-Hamming-distance neighbours are `ms` codex32 BIP 93, `md` Mnemonic Descriptor, `mm`, `my`)
- Codex32 BIP 93 (`ms`) — distinct from `mk`; cross-HRP false-positive validation prevented by BIP 173 HRP-mixing (≈ 2⁻⁶⁵ collision probability per cross-HRP mistype)
- Mnemonic Descriptor (`md`) — sibling format from the same project; deliberate 1-Hamming-distance pair to surface the family relationship without sharing the HRP
- Lightning Network HRPs (`lnbc`, `lntb`, `lnbcrt`, `lnsb`, `lno`, `lni`, `lnr`) — distinct
- Liquid sidechain (`ex`, `lq`, `el`, `tlq`, `ert`) — distinct
- Nostr NIP-19 (`npub`, `nsec`, `note`, etc.) — distinct
- Cosmos chain HRPs — distinct

**Cross-format separation** beyond HRP-mixing: `mk` and `md` use independent NUMS-derived target residues drawn from different domain strings (`shibbolethnumskey` and `shibbolethnums` respectively), so even an HRP-collision-prone construction would still need a constant collision to silently misvalidate.

**Status**: BIP draft is currently *Pre-Draft, AI + reference implementation, awaiting human review*. Latest release: [`mk-codec-v0.1.1`](https://github.com/bg002h/mnemonic-key/releases/tag/mk-codec-v0.1.1).

**Companion filing**: PR #2011 registers `md` for the sibling Mnemonic Descriptor format. Both filings share the same author, project, and design lineage. If #2011 merges first this PR will need a one-line rebase to insert `mk` after `md` rather than after `Lightning Network`; happy to do that on request.

Filing this defensive registration to close off future collision risk from independent projects.