### PR TITLE
SLIP-0044: register coin type 9508 for Monetarium

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1304,6 +1304,7 @@ All these constants are used as hardened derivation.
 | 9006       | 0x8000232e                    | BSC     | Binance Smart Chain               |
 | 9007       | 0x8000232f                    | SATOX   | Satoxcoin                         |
 | 9345       | 0x80002481                    | WEIL    | Weilliptic                        |
+| 9508       | 0x80002524                    | VARTA   | Monetarium                        |
 | 9555       | 0x80002553                    | RIN     | Rincoin                           |
 | 9797       | 0x80002645                    | NRG     | Energi                            |
 | 9888       | 0x800026a0                    | BTF     | Bitcoin Faith                     |


### PR DESCRIPTION
### Summary
This PR registers a new coin type index for **Monetarium (VARTA)** in accordance with the SLIP-0044 standard.

### Details
- **Coin Name:** Monetarium
- **Symbol:** VARTA — the native mined coin of the Monetarium chain. The chain also supports asset-backed tokens (SKA-1, SKA-2, …) which are derived under the same SLIP-0044 slot; per registry convention, the slot is named after the primary native coin.
- **Index:** 9508 (0x80002524)
- **Algorithm:** Hybrid PoW (BLAKE-256) + PoS ticket voting, derived from Decred's consensus model with multi-coin transaction semantics added on top (VARTA plus asset-backed SKA tokens).
- **Project repository:** https://github.com/monetarium/monetarium-node
- **Wallet repository:** https://github.com/monetarium/monetarium-wallet

### Status
Monetarium mainnet is live. The chain is past `StakeValidationHeight = 4096`, PoS ticket voting is active, and the
first asset-backed token (SKA-1) has emitted. The wallet SDK (`monetarium-wallet`) is tagged through v1.1.0 and is being integrated by a third-party desktop wallet (Skarb) for end-user release.

### BIP-0044 path
- Mainnet: `m/44'/9508'/<account>'/<branch>/<address index>`
- Testnet: `m/44'/1'/<account>'/<branch>/<address index>` (using the SLIP-0044 universal testnet slot, matching common hardware-wallet conventions)

### Migration context
Monetarium currently ships in chaincfg with `SLIP0044CoinType: 42` (Decred's slot), inherited from the upstream Decred codebase from which Monetarium was forked. Once this registration lands, the `monetarium-node` chaincfg will be updated to set the current value `42` as `LegacyCoinType` and `9508` as `SLIP0044CoinType`, mirroring Decred's own historical migration from coin type 20 to coin type 42. Wallet-side migration reuses the existing migration pattern in `monetarium-wallet/wallet/udb/`, so existing user funds are swept from the legacy derivation path to the new path automatically on
first launch after upgrade.

The chosen index 9508 matches the chain's mainnet P2P default port (for identity alignment), is verified unused in the current registry, and is hardcoded into the chaincfg patch awaiting this PR's acceptance — so the value will not change after registration.

Thank you for maintaining the registry.