### PR TITLE
slip-0044: add CS Coin (CS) coin type 19999

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1338,6 +1338,7 @@ All these constants are used as hardened derivation.
 | 19167      | 0x80004adf                    | FLUX    | Flux                              |
 | 19169      | 0x80004ae1                    | RITO    | Ritocoin                          |
 | 19788      | 0x80004d4c                    | ML      | Mintlayer                         |
+| 19999      | 0x80004e1f                    | CS      | Cloud Service                     |
 | 20036      | 0x80004e44                    | XND     | ndau                              |
 | 20760      | 0x80005118                    | WJK     | WojakCoin                         |
 | 21004      | 0x8000520c                    | C4EI    | c4ei                              |


### PR DESCRIPTION
Add CS Coin to SLIP-0044.                                                     
                                                                                
  | Field       | Value                        |                                
  |-------------|------------------------------|                                
  | Coin type   | 19999                        |                                
  | Path        | m/44'/19999'                 |                                
  | Symbol      | CS                           |                                
  | Name        | Cloud Service                      |                                
  | Hex         | 0x80004e1f                   |                                
                                                                                
  Cloud Service is a privacy-focused blockchain based on Zcash/Flux codebase. The coin type 19999 is not currently           
  registered in SLIP-0044.                                                      
                                                                                
  Project: https://cscloudservice.com                                           
  Source: https://github.com/MauricioSpagnol/cloudservice