### PR TITLE
slip-0044: add Tenzro (TNZO) coin type 1414421071

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1460,6 +1460,7 @@ All these constants are used as hardened derivation.
 | 1179993451 | 0xc655456b                    | RWA     | Asset Chain                       |
 | 1179993461 | 0xc6554575                    | HXC     | HuaXia Chain                      |
 | 1179993471 | 0xc655457f                    | AME     | AME Chain                         |
+| 1414421071 | 0xd44e5a4f                    | TNZO    | Tenzro                            |
 | 1869902945 | 0xef747461                    | ATTO    | Atto                              |
 | 1869902946 | 0xef747462                    | CTA     | Crypterra                         |
 


### PR DESCRIPTION
## Summary

Registers `TNZO` (Tenzro) as SLIP-44 coin type `1414421071` (`0xd44e5a4f`).

The hex form encodes the ASCII letters `T`, `N`, `Z`, `O` (with the high bit set on the leading byte to satisfy the hardened-derivation requirement), following the same convention used by recent registrations in the same range.

## Background

Tenzro is an L1 settlement layer with HotStuff-2 BFT consensus over a multi-VM execution layer (EVM + SVM + Canton/DAML) sharing a single native balance per asset (Sei-V2-style pointer model). The `TNZO` token is the native gas/fee/staking token on the Tenzro Ledger.

## BIP-0044 wallet implementation

`tenzro-wallet` is the reference BIP-44 wallet, in the Tenzro Network monorepo at <https://github.com/tenzro/tenzro-network/tree/main/crates/tenzro-wallet>. It supports:

- HD key derivation per BIP-44
- Threshold (MPC) wallet variants for multi-party signing
- Multiple curves (Ed25519 / Secp256k1) for the multi-VM façade

## References

- Tenzro Network: <https://github.com/tenzro/tenzro-network>
- TNZO whitepaper: <https://tenzro.com>
- CAIP-19 reference for `TNZO` (in flight): <https://github.com/ChainAgnostic/namespaces/pull/184>
