### PR TITLE
slip-0044: add Acki Nacki (NACKL)

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1085,6 +1085,7 @@ All these constants are used as hardened derivation.
 | 1308       | 0x8000051c                    | WEI     | WEI                               |
 | 1312       | 0x80000520                    | BITS    | Entropy                           |
 | 1313       | 0x80000521                    | GAEL    | Gaelium                           |
+| 1331       | 0x80000533                    | NACKL   | Acki Nacki                        |
 | 1337       | 0x80000539                    | DFC     | Defcoin                           |
 | 1338       | 0x8000053a                    | IRON    | Iron Fish                         |
 | 1339       | 0x8000053b                    | WNSD    | Winsdet                           |


### PR DESCRIPTION
This PR registers a new SLIP-0044 coin type for **Acki Nacki**, an independent Layer 1 blockchain network.

## Coin
- **Symbol**: NACKL
- **Name**: Acki Nacki
- **coin_type**: 1331 (`0x80000533`)

## Motivation

Acki Nacki is a fully independent Layer 1 with its own consensus protocol (probabilistic Proof-of-Stake with fast finality), live mainnet, and tokenomics, and requires its own `coin_type` to avoid address collisions when users import the same mnemonic across both networks.

## About the network

Acki Nacki is a Probabilistic Proof-of-Stake blockchain with fast finality and parallelized execution, written in Rust. It uses a dual-token model:
- **NACKL** — native coin, mined as block rewards (no pre-mine, no TGE, no team or investor allocation), used for staking and securing the network at the consensus level
- **SHELL** — secondary gas token used for transaction fees

NACKL is the native protocol asset and the appropriate symbol for SLIP-44 registration.

## BIP-44 implementation

Acki Nacki supports BIP-32 / BIP-39 / BIP-44 hierarchical deterministic derivation through its official SDK. The current production derivation path is `m/44'/396'/0'/0/0`, which this PR resolves by registering a dedicated coin_type.

References:
- Official Acki Nacki developer documentation for the crypto module (BIP-44 derivation, mnemonics, HD keys): https://dev.ackinacki.com/acki-nacki-sdk/types-and-methods/mod_crypto.md
- SDK source (actively maintained, official Acki Nacki SDK): https://github.com/tvmlabs/tvm-sdk
- Crypto module reference with `hdkey_xprv_from_mnemonic`, `hdkey_derive_from_xprv_path`, `mnemonic_derive_sign_keys`: https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/mod_crypto.md

The Acki Nacki Wallet (iOS/Android) uses this SDK to generate keypairs from BIP-39 mnemonics via standard BIP-44 paths.

## Reference links

- Website: https://ackinacki.com
- General documentation: https://docs.ackinacki.com
- Tokenomics: https://docs.ackinacki.com/tokenomics
- Developer documentation: https://dev.ackinacki.com
- Block explorer: https://ackiscan.com
- Node implementation: https://github.com/ackinacki/ackinacki

## Network status

Acki Nacki mainnet is live. NACKL is actively mined as block rewards and used in the network today.
