### PR TITLE
docs(slip-0039): add shurlinet/go-slip39 to other implementations

### DIFF
--- a/slip-0039.md
+++ b/slip-0039.md
@@ -331,6 +331,7 @@ Dart:
 Go:
 
 * <https://github.com/gavincarr/go-slip39>
+* <https://github.com/shurlinet/go-slip39>
 
 JavaScript:
 


### PR DESCRIPTION
Adds [shurlinet/go-slip39](https://github.com/shurlinet/go-slip39) to the Go implementations list.

- Full SLIP-0039 spec implementation (all 45 test vectors pass)
- Constant-time bitsliced GF(2^8) translated from Trezor firmware crypto/shamir.c
- Memory zeroing, fuzz testing, cross-implementation verification against python-shamir-mnemonic
- MIT license, single dependency (golang.org/x/crypto for PBKDF2)
- https://pkg.go.dev/github.com/shurlinet/go-slip39