### PR TITLE
Add B3Chain (B3C) coin type 9333

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1303,6 +1303,7 @@ All these constants are used as hardened derivation.
 | 9005       | 0x8000232d                    | AVAXC   | Avalanche C-Chain                 |
 | 9006       | 0x8000232e                    | BSC     | Binance Smart Chain               |
 | 9007       | 0x8000232f                    | SATOX   | Satoxcoin                         |
+| 9333       | 0x80002475                    | B3C     | B3Chain                           |
 | 9345       | 0x80002481                    | WEIL    | Weilliptic                        |
 | 9555       | 0x80002553                    | RIN     | Rincoin                           |
 | 9797       | 0x80002645                    | NRG     | Energi                            |


### PR DESCRIPTION
This PR registers BIP44 `coin_type` **9333** for **B3Chain (B3C)**, a Bitcoin Core fork that replaces SHA-256d proof-of-work with double BLAKE3-256.

| Field | Value |
|---|---|
| Coin type (decimal) | `9333` |
| Coin type (hex) | `0x80002475` |
| Symbol | `B3C` |
| Name | `B3Chain` |
| Website | https://b3chain.org |
| Source | https://github.com/b3chain/b3chain (`b3chain-main`) |
| Rationale | https://github.com/b3chain/b3chain/blob/b3chain-main/doc/b3chain-bip44.md |

### Why 9333

* Not currently assigned in `slip-0044.md` (the 9216–16383 band is unallocated as of writing).
* Mnemonic: `9` is the first decimal digit not used by Bitcoin (`0`); `333` is symbolic for "B3Chain".
* Outside common ranges (Ethereum 60, Litecoin 2, BCH 145, DOGE 3, Zcash 133).
* 4-digit, all-decimal value.

### What is B3Chain

A Layer-1 PoW chain forked from Bitcoin Core 30.x, replacing the PoW algorithm with double BLAKE3-256 while keeping SHA-256 for block IDs. Mainnet launch is in preparation; the wallet code already uses `coin_type 9333` on mainnet and the BIP44-reserved `1` on testnet/regtest.

* Phase 11 self-audit (including a dedicated audit for this `coin_type` choice): https://b3chain.org/testing/audit-hd-coin-type.html
* Wallet implementation: https://github.com/b3chain/b3chain/blob/b3chain-main/src/wallet/walletutil.cpp

Happy to provide additional information if needed.
