### PR TITLE
slip-0044: add CERA (coin type 68291)

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1368,6 +1368,7 @@ All these constants are used as hardened derivation.
 | 61616      | 0x8000f0b0                    | TH      | TianHe                            |
 | 61888      | 0x8000f200                    | MORM    | Morpheum                          |
 | 65536      | 0x80010000                    | KETH    | Krypton World                     |
+| 68291      | 0x80010A73                    | CERA    | CERA                              |
 | 69420      | 0x80010f2c                    | GRLC    | Garlicoin                         |
 | 70007      | 0x80011177                    | GWL     | Gewel                             |
 | 83293      | 0x8001455d                    | QUBIC   | Qubic                             |


### PR DESCRIPTION
## Summary

Register coin type **68291** for **CERA** (BIP-44 / SLIP-0044).

## Project

- **Name:** CERA
- **Symbol:** CERA
- **Website:** https://cera.cash
- **Wallet:** https://wallet.cera.cash
- **Public wallet implementation:** https://github.com/cera-chain/cera-wallet
- **Protocol documentation:** https://cera.cash/docs/cera-chain/index.html
- **Maintainer:** CERA Protocol Maintainers — cerachain2026@gmail.com

## Derivation

- **Path:** `m/44'/68291'/0'/0'/0'`
- **Mnemonic:** BIP-39, 24 words (256-bit entropy), English wordlist
- **Curve / SLIP-0010:** Ed25519 with hardened derivation at each level (no non-hardened path segments)
- **Documentation:** https://github.com/cera-chain/cera-wallet/blob/main/backend/docs/mnemonic-derivation-and-coin-type.md

## Existing implementation

A reference wallet (TypeScript, backend + browser frontend) already derives keys with this path. Tests assert `derivation_path === "m/44'/68291'/0'/0'/0'"`.

## Checklist

- [x] Row added in numeric order in `slip-0044.md`
- [x] Coin type not already used by another entry
- [x] Public repo and docs available for review