### PR TITLE
slip-0039: fix polynomial degree inaccuracy

### DIFF
--- a/slip-0039.md
+++ b/slip-0039.md
@@ -69,7 +69,7 @@ However, the lack of SSS standardization to date presents a risk of being unable
 
 ## Shamir's secret-sharing
 
-Shamir's secret-sharing (SSS) is a cryptographic mechanism describing how to split a secret into *N* unique parts, where any *T* of them are required to reconstruct the secret. First, a polynomial *f* of degree *T* &minus; 1 is constructed and each party is given a corresponding point - an integer input *x* to the polynomial and the corresponding output *f*(*x*).
+Shamir's secret-sharing (SSS) is a cryptographic mechanism describing how to split a secret into *N* unique parts, where any *T* of them are required to reconstruct the secret. First, a polynomial *f* of degree &lt;*T* is constructed and each party is given a corresponding point - an integer input *x* to the polynomial and the corresponding output *f*(*x*).
 
 When any *T* points are provided, they exactly define the polynomial. Usually the value of the polynomial *f*(0) is used as the shared secret. In this specification the shared secret is stored as *f*(255)<sup>[3](#IndexEncoding)</sup>. More details on SSS can be found on [Wikipedia](https://en.wikipedia.org/wiki/Shamir%27s_Secret_Sharing).
 


### PR DESCRIPTION
SLIP-0039 says the following, describing the Shamir secret sharing algorithm:
> First, a **polynomial f of degree T−1** is constructed and each party is given a corresponding point - a non-zero integer x input to the polynomial and the corresponding output f(x).

However, since the coefficients are random, it could be the case that, e.g. T=3 but all randomly-chosen coefficients are zero. This would result in a degree zero polynomial, which is notably not degree T-1. Thus the specification should instead say **degree <T**, which is what this PR changes it to.

Moreover, if the specification truly does require a degree T-1 polynomial, then that is insecure, as it reveals information about the secret. For example, for T>1, you cannot have f with degree 0, so if you have a share (x, y=f(x)), then you know that the secret is not y.