### PR TITLE
SLIP-0044: reserve coin types for SSH, OpenPGP, X.509 and WireGuard

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1077,6 +1077,10 @@ All these constants are used as hardened derivation.
 | 1234       | 0x800004d2                    | ALPH    | Alephium                          |
 | 1236       | 0x800004d4                    |         | Masca                             |
 | 1237       | 0x800004d5                    |         | Nostr                             |
+| 1238       | 0x800004d6                    |         | SSH                               |
+| 1239       | 0x800004d7                    |         | OpenPGP                           |
+| 1240       | 0x800004d8                    |         | X.509                             |
+| 1241       | 0x800004d9                    |         | WireGuard                         |
 | 1280       | 0x80000500                    |         | Kudos Setler                      |
 | 1284       | 0x80000504                    | GLMR    | Moonbeam                          |
 | 1285       | 0x80000505                    | MOVR    | Moonriver                         |


### PR DESCRIPTION
This PR proposes four additional SLIP-0044 entries in the same numeric area as Nostr (1237):\n\n- 1238 -> SSH\n- 1239 -> OpenPGP\n- 1240 -> X.509\n- 1241 -> WireGuard\n\nMotivation:\n- support deterministic HD key separation for widely used security protocols\n- keep protocol namespaces adjacent to existing non-Bitcoin protocol usage (Nostr)\n\nNotes:\n- S/MIME and TLS certificate keys are intentionally covered under X.509, with usage distinctions expected at lower derivation-path levels (role/config), not as separate protocol IDs.