### PR TITLE
Add BTCC Bitcoin-Classic to SLIP-0044.md

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -313,6 +313,7 @@ All these constants are used as hardened derivation.
 | 282        | 0x8000011a                    | BRAVO   | BRAVO                             |
 | 283        | 0x8000011b                    | ALGO    | Algorand                          |
 | 284        | 0x8000011c                    | BZX     | Bitcoinzero                       |
+| 28465      | 0x80006f31                    | BTCC    | Bitcoin-Classic                   |
 | 285        | 0x8000011d                    | GXX     | GravityCoin                       |
 | 286        | 0x8000011e                    | HEAT    | HEAT                              |
 | 287        | 0x8000011f                    | XDN     | DigitalNote                       |


### PR DESCRIPTION
This PR adds BTCC (Bitcoin-Classic) to the SLIP-0044 registry.

Coin name: Bitcoin-Classic
Symbol: BTCC
Coin type: 28465
Derivation path: m/84'/28465'/0'/0/0

Official website:
https://btc-classic.org/

Repository:
https://github.com/Marcus-Vane/Bitcoin-Classic