### PR TITLE
Add Arc coin type 5042 (USDC) to SLIP-0044.md

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1238,6 +1238,7 @@ All these constants are used as hardened derivation.
 | 4999       | 0x80001387                    | BXN     | BlackFort Exchange Network        |
 | 5000       | 0x80001388                    | V12     | Vet The Vote                      |
 | 5006       | 0x8000138e                    | SBC     | Senior Blockchain                 |
+| 5042       | 0x800013b2                    | USDC    | Arc                               |
 | 5248       | 0x80001480                    | FIC     | FIC                               |
 | 5353       | 0x800014e9                    | HNS     | Handshake                         |
 | 5404       | 0x8000151c                    | ISK     | ISKRA                             |


### PR DESCRIPTION
This Pull Request adds Arc (USDC) to SLIP-0044.

- Coin type: 5042
- Symbol: USDC
- Name: Arc

Arc is a blockchain whose native gas token is USDC. This registration enables BIP-0044 address/account derivation for Arc mainnet.

Source code: https://github.com/circlefin/arc-node

Thank you.