### PR TITLE
feat: add coin type for BEXChain native coin (BEX)

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1462,6 +1462,7 @@ All these constants are used as hardened derivation.
 | 1179993471 | 0xc655457f                    | AME     | AME Chain                         |
 | 1869902945 | 0xef747461                    | ATTO    | Atto                              |
 | 1869902946 | 0xef747462                    | CTA     | Crypterra                         |
+| 140586     | 0x8002252a                    | BEX     | BEXChain                          |
 
 Coin types will be added only if there is a wallet implementing BIP-0044 for desired coin.
 


### PR DESCRIPTION
Registering the official Coin Type ID for BEXChain native coin (BEX) based on its EVM Chain ID.

- Coin Name: BEXChain
- Symbol: BEX
- Coin Type ID: 140586 (0x8002252a)
- Website: https://bexchain.com
