### PR TITLE
Add DebitMyData (DMD) coin type 4134

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1233,6 +1233,7 @@ The hardened path component for coin type `n` is computed as `0x80000000 + n`.
 | 3840       | RED     | ReDeFi RED                        |
 | 4040       | FC8     | FCH Network                       |
 | 4096       | YEE     | YeeCo                             |
+| 4134       | DMD     | DebitMyData                       |
 | 4218       | IOTA    | IOTA                              |
 | 4219       | SMR     | Shimmer                           |
 | 4242       | AXE     | Axe                               |


### PR DESCRIPTION
This Pull Request registers DebitMyData (DMD) in SLIP-0044.

* Coin type: 4134
* Symbol: DMD
* Name: DebitMyData

DebitMyData is a Bitcoin-derived SHA-256 Proof-of-Work blockchain with native SegWit support and bech32 addresses using the HRP "dm".

Project repository: https://github.com/DebitMyData-PoW/DebitMyData-PoW-Core

Thank you for your consideration.