### PR TITLE
Register BEXChain (Coin Type 140586) in SLIP-0044

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1462,6 +1462,7 @@ All these constants are used as hardened derivation.
 | 1179993471 | 0xc655457f                    | AME     | AME Chain                         |
 | 1869902945 | 0xef747461                    | ATTO    | Atto                              |
 | 1869902946 | 0xef747462                    | CTA     | Crypterra                         |
+| 140586     | 0x8002252a                    | BEX     | BEXChain                          |
 
 Coin types will be added only if there is a wallet implementing BIP-0044 for desired coin.
 


### PR DESCRIPTION
### Description
This PR registers the official Coin Type for BEXChain in `slip-0044.md`.

### Details
- **Coin Type:** 140586 (0x0002252a)
- **Coin Name:** BEXChain
- **Symbol:** BEX
- **Status:** Complete implementation with BIP-39 mnemonic and BIP-44 derivation paths actively validated.

Our implementation and test documentation are fully updated on our repository. Thank you for reviewing!
