### PR TITLE
Register BEXChain (Coin Type 140586) in SLIP-0044 - Sorted

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1462,6 +1462,7 @@ All these constants are used as hardened derivation.
 | 1179993471 | 0xc655457f                    | AME     | AME Chain                         |
 | 1869902945 | 0xef747461                    | ATTO    | Atto                              |
 | 1869902946 | 0xef747462                    | CTA     | Crypterra                         |
+| 140586     | 0x8002252a                    | BEX     | BEXChain                          |
 
 Coin types will be added only if there is a wallet implementing BIP-0044 for desired coin.
 

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1398,6 +1398,7 @@ All these constants are used as hardened derivation.
 | 121337     | 0x8001d9f9                    | KLS     | Karlsen                           |
 | 123456     | 0x8001e240                    | SPR     | Spectre                           |
 | 130822     | 0x8001ff06                    | WBT     | WhiteBIT Coin                     |
+| 140586     | 0x8002252a                    | BEX     | BEXChain                          |
 | 161803     | 0x8002780b                    | APTA    | Bloqs4Good                        |
 | 189189     | 0x8002e305                    | QUAN    | Quantus Network                   |
 | 190301     | 0x8002e75d                    | LOCUS   | Locus Chain                       | 
@@ -1481,7 +1482,6 @@ All these constants are used as hardened derivation.
 | 1414421071 | 0xd44e5a4f                    | TNZO    | Tenzro                            |
 | 1869902945 | 0xef747461                    | ATTO    | Atto                              |
 | 1869902946 | 0xef747462                    | CTA     | Crypterra                         |
-| 140586     | 0x8002252a                    | BEX     | BEXChain                          |
 | 1869902947 | 0xef747463                    | SOST    | Sovereign Stock Token             |
 
 Coin types will be added only if there is a wallet implementing BIP-0044 for desired coin.


### PR DESCRIPTION
### Description
This PR registers the official Coin Type for BEXChain in `slip-0044.md`.

### Details
- **Coin Type:** 140586 (0x0002252a)
- **Coin Name:** BEXChain
- **Symbol:** BEX

The list has been properly sorted in ascending order numerically (placed between 130822 and 161803) as per maintainer feedback. Thank you for reviewing!
