### PR TITLE
slip-0044: add eCurrency (ECR) cointype 8128

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1288,6 +1288,7 @@ The hardened path component for coin type `n` is computed as `0x80000000 + n`.
 | 8008       | BERA    | Berachain                         |
 | 8017       | ISC     | iSunCoin                          |
 | 8080       |         | DSRV                              |
+| 8128       | ECR     | eCurrency                         |
 | 8181       | BOC     | BeOne Chain                       |
 | 8192       | PAC     | pacprotocol                       |
 | 8217       | KAIA    | KAIA                              |


### PR DESCRIPTION
This Pull Request registers eCurrency (ECR) in SLIP-0044.

    Coin type: 8128
    Symbol: ECR
    Name: eCurrency

eCurrency is Proof-of-Stake blockchain with UTXO architecture and post-quantum encryption algorithm (Falcon).
Source code: https://github.com/ecurrency-project/ecurrency-pos
Wallet apps: https://ecurrency.org/wallets
Whitepaper: https://ecurrency.org/whitepaper

Thank you for your consideration