### PR TITLE
slip-0044: add Bitcoin-PoCX (BTCX) coin type 1347371864

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1483,6 +1483,7 @@ The hardened path component for coin type `n` is computed as `0x80000000 + n`.
 | 1179993451 | RWA     | Asset Chain                       |
 | 1179993461 | HXC     | HuaXia Chain                      |
 | 1179993471 | AME     | AME Chain                         |
+| 1347371864 | BTCX    | Bitcoin-PoCX                      |
 | 1414421071 | TNZO    | Tenzro                            |
 | 1869902945 | ATTO    | Atto                              |
 | 1869902946 | CTA     | Crypterra                         |


### PR DESCRIPTION
Registers coin type **1347371864** (`0x504F4358`, POCX in ASCII) for **Bitcoin-PoCX (BTCX)**, a Bitcoin fork using Proof of Capacity consensus.

- Project (node): https://github.com/PoC-Consortium/bitcoin-pocx
- Wallet implementing this coin type: https://github.com/PoC-Consortium/satchel (BIP-86 derivation `m/86'/1347371864'/0'`, BDK-based)
- Additional wallet: https://github.com/PoC-Consortium/phoenix-pocx

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPL3YMrCwmR4F9spFFL2Zp