### PR TITLE
Add Brisvia (BRVA), coin type 9339

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1318,6 +1318,7 @@ The hardened path component for coin type `n` is computed as `0x80000000 + n`.
 | 9006       | BSC     | Binance Smart Chain               |
 | 9007       | SATOX   | Satoxcoin                         |
 | 9333       | B3C     | B3Chain                           |
+| 9339       | BRVA    | Brisvia                           |
 | 9345       | WEIL    | Weilliptic                        |
 | 9508       | VARTA   | Monetarium                        |
 | 9555       | RIN     | Rincoin                           |


### PR DESCRIPTION
Registers coin type 9339 for Brisvia (BRVA).

Brisvia is an open-source, CPU-mineable Proof-of-Work cryptocurrency (Bitcoin Core fork + RandomX) with a fair launch (no premine, finite 100M supply). Mainnet launches on 2026-08-01. Wallets derive keys at m/84'/9339'/0' (BIP84).

9339 is currently unused in the registry (it sits between 9333 and 9345). Website: https://brisvia.com — Source: https://github.com/brisvia/brisvia