### PR TITLE
slip-0044: add XYNC (Xync Network)

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1060,6 +1060,7 @@ The hardened path component for coin type `n` is computed as `0x80000000 + n`.
 | 1026       | KEX     | Kira Exchange Token               |
 | 1027       | MCM     | Mochimo                           |
 | 1028       | PLS     | Pulse Coin                        |
+| 1030       | XYNC    | Xync Network                      |
 | 1032       | BTCR    | BTCR                              |
 | 1042       | MFID    | Moonfish ID                       |
 | 1100       | CROSS   | Cross Chain                       |


### PR DESCRIPTION
Registers coin type **1030** for **XYNC**, the native token of
[Xync Network](https://xync.net) — a payments-only Layer-1 blockchain
(send / request money in up to 255 protocol-native currencies; no VM).

- **Symbol:** XYNC
- **Coin:** Xync Network
- **Coin type:** 1030 (hardened path component `0x80000000 + 1030 = 0x80000406`)
- **HD derivation:** `m/44'/1030'/0'/0/i`

The value 1030 is currently unassigned (it sits in the gap between 1028
and 1032 and is not a reserved/blanked entry). The network runs a live
payment product (XyncPay, Telegram Mini App @XyncPayBot).

Reference: [Xync Network Yellow Paper](https://xync.net/papers/yellowpaper.en.pdf).
