### PR TITLE
Register coin_type 1370 for Elektron Net (ELEK)

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1098,6 +1098,7 @@ The hardened path component for coin type `n` is computed as `0x80000000 + n`.
 | 1338       | IRON    | Iron Fish                         |
 | 1339       | WNSD    | Winsdet                           |
 | 1348       | ISLM    | IslamicCoin                       |
+| 1370       | ELEK    | Elektron Net                      |
 | 1397       | HYC     | Hycon                             |
 | 1410       | TENTSLP | TENT Simple Ledger Protocol       |
 | 1420       | DEV     | DogecoinEV                        |

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1098,7 +1098,7 @@ The hardened path component for coin type `n` is computed as `0x80000000 + n`.
 | 1338       | IRON    | Iron Fish                         |
 | 1339       | WNSD    | Winsdet                           |
 | 1348       | ISLM    | IslamicCoin                       |
-| 1370       | ELEK    | Elektron Net                      |
+| 1370       | ELEK    | Elektron                          |
 | 1397       | HYC     | Hycon                             |
 | 1410       | TENTSLP | TENT Simple Ledger Protocol       |
 | 1420       | DEV     | DogecoinEV                        |


### PR DESCRIPTION
Registers coin type 1370 for ELEK, the native token of **Elektron Net** — a minimal, privacy-focused fork of Bitcoin Core with 60-second blocks and mandatory 137-day pruning (mathematically enforced right-to-be-forgotten; recovery via live UTXO-set scan instead of unbounded history).

* Symbol: ELEK
* Coin: Elektron
* Coin type: 1370 (hardened path component `0x80000000 + 1370 = 0x8000055A`)
* HD derivation: `m/44'/1370'/0'/0/i` (also `49'`/`84'`/`86'` purpose paths, standard BIP-44/49/84/86)

The value 1370 is currently unassigned (it sits in the gap between 1348 and 1397 and is not a reserved/blanked entry). The reference node wallet (`elektrond`) already implements standard BIP-44 descriptor derivation.
Reference: [[Elektron Net Whitepaper](https://github.com/kutlusoy/elektron-net/blob/main/WHITEPAPER.md)](https://github.com/kutlusoy/elektron-net/blob/main/WHITEPAPER.md)