### PR TITLE
Add 5TRAT coin type

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1257,6 +1257,7 @@ The hardened path component for coin type `n` is computed as `0x80000000 + n`.
 | 5404       | ISK     | ISKRA                             |
 | 5467       | ALTME   | ALTME                             |
 | 5555       | FUND    | Unification                       |
+| 5755       | 5TRAT   | 5tratum Coin                      |
 | 5757       | STX     | Stacks                            |
 | 5895       | VOW     | VowChain VOW                      |
 | 5920       | SLU     | SILUBIUM                          |


### PR DESCRIPTION
Adds coin type `5755` for 5tratum Coin (`5TRAT`).

The HD wallet implementation uses `m/44'/5755'` in the public Komodo DeFi Framework integration package:
https://github.com/WillItMod/5tratSmack/tree/main/integrations/komodo

The derivation has been exercised in a completed native 5TRAT/DGB atomic swap. Public swap evidence and all five settlement transactions are included in the true upstream coin-registry submission:
https://github.com/GLEECBTC/coins/pull/1903

Project website:
https://5trat.com

Public Core source:
https://github.com/WillItMod/5trat-core

Independent public explorers:
- https://explorer1.5trat.net/explorer/
- https://explorer2.5trat.net/explorer/