### PR TITLE
slip-0044: add Irys (IRYS) for coin type 3282

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1219,6 +1219,7 @@ The hardened path component for coin type `n` is computed as `0x80000000 + n`.
 | 3131       | DIP     | Dipnet Blockchain                 |
 | 3141       | B1T     | Bit                               |
 | 3276       | CCC     | CodeChain                         |
+| 3282       | IRYS    | Irys                              |
 | 3333       | SXP     | Solar                             |
 | 3338       | PEAQ    | peaq                              |
 | 3344       | PLMC    | Polimec                           |


### PR DESCRIPTION
Adds a slip-0044 entry for Irys (type 3282)