### PR TITLE
SLIP-0173: register Zerone zrn HRP

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -307,6 +307,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | XPLA                     | `xpla`        |          |             |
 | YeeCo                    | `yee`         | `tyee`   |             |
 | Zen Protocol             | `zen`         | `tzn`    |             |
+| Zerone                   | `zrn`         |          |             |
 | ZetaChain                | `zeta`        |          |             |
 | ZIGChain                 | `zig`         |          |             |
 | Zilliqa                  | `zil`         | `tzil`   |             |


### PR DESCRIPTION
## Summary

Register `zrn` as the mainnet Bech32 human-readable part for [Zerone](https://zerone.ai/).

## Evidence

- The public source config sets the account prefix to `zrn`: https://github.com/cambridgetcg/zerone-core/blob/main/app/app.go
- The live mainnet is `zerone-1`: https://zerone.ai/
- The committed genesis contains canonical `zrn1...` accounts: https://github.com/cambridgetcg/zerone-core/blob/main/deploy/mainnet/artifacts/genesis.json

No testnet or regtest HRP is claimed.