### PR TITLE
Add PISO Chain entry to slip-0044.md

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1177,6 +1177,7 @@ The hardened path component for coin type `n` is computed as `0x80000000 + n`.
 | 2025       | ROCK    | Zenrock Labs                      |
 | 2026       | ASTRON  | ASTRON Token                      |
 | 2027       | UNC     | UniCash                           |
+| 2028       | PISO    | PISO Chain                        |
 | 2046       | ANY     | Any                               |
 | 2048       | MCASH   | MCashChain                        |
 | 2049       | TRUE    | TrueChain                         |
@@ -1495,7 +1496,7 @@ The hardened path component for coin type `n` is computed as `0x80000000 + n`.
 | 1869902945 | ATTO    | Atto                              |
 | 1869902946 | CTA     | Crypterra                         |
 | 1869902947 | SOST    | Sovereign Stock Token             |
-
+| 2026 | PISO | PISO Chain |
 Coin types will be added only if there is a wallet implementing BIP-0044 for desired coin.
 
 ## Libraries

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1496,6 +1496,7 @@ The hardened path component for coin type `n` is computed as `0x80000000 + n`.
 | 1869902945 | ATTO    | Atto                              |
 | 1869902946 | CTA     | Crypterra                         |
 | 1869902947 | SOST    | Sovereign Stock Token             |
+
 Coin types will be added only if there is a wallet implementing BIP-0044 for desired coin.
 
 ## Libraries

--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1496,7 +1496,6 @@ The hardened path component for coin type `n` is computed as `0x80000000 + n`.
 | 1869902945 | ATTO    | Atto                              |
 | 1869902946 | CTA     | Crypterra                         |
 | 1869902947 | SOST    | Sovereign Stock Token             |
-| 2026 | PISO | PISO Chain |
 Coin types will be added only if there is a wallet implementing BIP-0044 for desired coin.
 
 ## Libraries


### PR DESCRIPTION
Summary

Register a new SLIP-0044 coin type for PISO Chain.

Project
- Name: PISO Chain
- Symbol: PISO
- Coin Type (Decimal): 2028
- Coin Type (Hex): `0x000007EC`
- Derivation Path: `m/44'/2028'/0'/0/0`
- Chain Type: Layer 1 Blockchain
- Repository: https://github.com/314-hash/piso-chain

Notes
- Verified that Coin Type 2026 was assigned to ASTRON Token; selected next available unassigned coin type **2028**.
- Table formatting follows repository conventions.
- No existing entries were modified.
