### PR TITLE
slip-0044.md: add cointype 2009 for qBitcoin (QBTC)

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1163,6 +1163,7 @@ The hardened path component for coin type `n` is computed as `0x80000000 + n`.
 | 2001       | MNP     | MNPCoin                           |
 | 2002       | MLN     | Miraland                          |
 | 2003       | ISNA    | iSarrana                          |
+| 2009       | QBTC    | qBitcoin                          |
 | 2010       | XBT     | Bitcoin Classic                   |
 | 2013       | JKC     | Junkcoin                          |
 | 2015       | TEER    | Integritee                        |


### PR DESCRIPTION
This Pull Request registers qBitcoin (QBTC) in SLIP-0044.

Coin type: 2009
Symbol: QBTC
Name: qBitcoin
qBitcoin is Proof-of-Stake blockchain with UTXO architecture and post-quantum encryption algorithm (Falcon).
Source code: https://github.com/qbitcoin-project/qbitcoin
Wallet app: https://github.com/qbitcoin-project/qbitcoin-desktop

Thank you for your consideration