### PR TITLE
slip-0044: add Interverse (IVX) - 3157

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1218,6 +1218,7 @@ The hardened path component for coin type `n` is computed as `0x80000000 + n`.
 | 3077       | COS     | Contentos                         |
 | 3131       | DIP     | Dipnet Blockchain                 |
 | 3141       | B1T     | Bit                               |
+| 3157       | IVX     | Interverse                        |
 | 3276       | CCC     | CodeChain                         |
 | 3282       | IRYS    | Irys                              |
 | 3333       | SXP     | Solar                             |


### PR DESCRIPTION
Registering coin type 3157 for Interverse (IVX), a secp256k1-based chain. Derivation path m/44'/3157'/0'/0/0.