### PR TITLE
slip-0044: add SELEMAN (SMN) coin type 73571

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1400,6 +1400,7 @@ The hardened path component for coin type `n` is computed as `0x80000000 + n`.
 | 68291      | CERA    | CERA                              |
 | 69420      | GRLC    | Garlicoin                         |
 | 70007      | GWL     | Gewel                             |
+| 73571      | SMN     | SELEMAN                           |
 | 77777      | ZYN     | Wethio                            |
 | 83293      | QUBIC   | Qubic                             |
 | 88888      | RYO     | c0ban                             |


### PR DESCRIPTION
## Summary

Register SLIP-0044 coin type **73571** for **SELEMAN** (`SMN`), matching EVM chainId `73571` (`0x11f63`).

| Field | Value |
|-------|-------|
| Coin type | 73571 |
| Symbol | SMN |
| Name | SELEMAN |
| URL | https://seleman.monarcaproject.com/seleman-chain |
| Explorer | https://seleman.monarcaproject.com |
| Chainlist | https://chainlist.org/chain/73571 |

Derivation path: `m/44'/73571'/0'/0/0`

## Context

Follow-up to https://github.com/satoshilabs/slips/issues/2040 (closed with request to open a PR).

Public HTTPS RPC + WSS are live. SELEMAN is already listed on Chainlist (#2967 merged).

Thank you.