### PR TITLE
slip-0044: add Pharos (PROS) - 3172

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1220,6 +1220,7 @@ The hardened path component for coin type `n` is computed as `0x80000000 + n`.
 | 3131       | DIP     | Dipnet Blockchain                 |
 | 3141       | B1T     | Bit                               |
 | 3157       | IVX     | Interverse                        |
+| 3172       | PROS    | Pharos                            |
 | 3276       | CCC     | CodeChain                         |
 | 3282       | IRYS    | Irys                              |
 | 3333       | SXP     | Solar                             |


### PR DESCRIPTION
Registering coin type 3172 for Pharos (PROS), a secp256k1-based chain. Derivation path m/44'/3172'/0'/0/0.