### PR TITLE
slip-0044: add Somnia (SOMI)

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1255,6 +1255,7 @@ The hardened path component for coin type `n` is computed as `0x80000000 + n`.
 | 4999       | BXN     | BlackFort Exchange Network        |
 | 5000       | V12     | Vet The Vote                      |
 | 5006       | SBC     | Senior Blockchain                 |
+| 5031       | SOMI    | Somnia                            |
 | 5042       | USDC    | Arc                               |
 | 5050       | TAR     | TARCOIN                           |
 | 5248       | FIC     | FIC                               |


### PR DESCRIPTION
Adds Somnia to the SLIP-0044 registered coin types.

- Coin type: 5031 (matches the EVM chain ID)
- Symbol: SOMI
- Somnia is a live EVM Layer 1 mainnet (launched September 2025): https://somnia.network
- Chain ID 5031: https://chainlist.org/chain/5031
- Explorer: https://explorer.somnia.network
- Docs: https://docs.somnia.network