### PR TITLE
slip-0044: add Bitflash

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1446,6 +1446,7 @@ The hardened path component for coin type `n` is computed as `0x80000000 + n`.
 | 1712144    | LAX     | LAPO                              |
 | 3924011    | EPK     | EPIK Protocol                     |
 | 4151811    | DORK    | Dorkcoin                          |
+| 4346950    | BITFLASH | Bitflash                         |
 | 4353123    | BBLU    | Bitcoin-Blu                       |
 | 4392018    | MCSH    | MetaMask Cash Account             |
 | 4741444    | HYD     | Hydra Token                       |


### PR DESCRIPTION
Adds a coin type for Bitflash.

- **Coin type:** 4346950 — this is 0x425446, the ASCII bytes of "BTF".
- **Symbol:** BITFLASH. The BTF ticker is already registered (9888, Bitcoin
  Faith), so the coin name is used instead of the ticker.
- **Coin:** Bitflash

Bitflash is a live CPU-mined cryptocurrency: Bitcoin 0.1.0 consensus with
RandomX proof of work, no premine.

Per the requirement that a coin type is added only when a wallet implements
BIP-44 for the coin:

- BIP-44 HD wallet implementation (twelve-word BIP39 seed + BIP32 derivation),
  in the released node: https://git.bitflash.network/bitflash/bitflash
- Derivation specification — paths, address format, encoding and test vectors,
  plus a standalone verifier that reproduces them with only Python's standard
  library: https://docs.bitflash.network/derivation.html
- The wallet has been exercised on the live chain with real coins.

4346950 is currently unused in slip-0044.md. If BITFLASH (8 chars) is too wide
for the symbol column, I'm happy to shorten it.
