### PR TITLE
slip-0044: rename XinFin to XDC Network

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -580,7 +580,7 @@ The hardened path component for coin type `n` is computed as `0x80000000 + n`.
 | 547        | BHP     | BHP                               |
 | 548        | BBC     | BigBang Core                      |
 | 549        | MKF     | MarketFinance                     |
-| 550        | XDC     | XinFin                            |
+| 550        | XDC     | XDC Network                       |
 | 551        | STR     | Straightedge                      |
 | 552        | SUM     | Sumcoin                           |
 | 553        | HBC     | HuobiChain                        |


### PR DESCRIPTION
Coin type 550 (symbol `XDC`) has been registered since 2019 under the project's original name, XinFin. The network rebranded to **XDC Network**, which is the name used by the project itself ([xdc.org](https://xdc.org/)), by its documentation and explorers, and by exchanges and data providers. The `XinFin` label is now stale.

**Before**

```
| 550        | XDC     | XinFin                            |
```

**After**

```
| 550        | XDC     | XDC Network                       |
```

Coin type and symbol are unchanged, so no derivation path is affected — this is a display-name update only. Same shape as the `144 | XRP | Ripple` → `144 | XRP | XRP` rename in #1761.

`check.sh` passes: no new duplicate coin names, no uppercase-hex hits, and the column alignment is preserved.
