### PR TITLE
slip-0044: add Zig Zag (ZIG)

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1060,6 +1060,7 @@ The hardened path component for coin type `n` is computed as `0x80000000 + n`.
 | 1026       | KEX     | Kira Exchange Token               |
 | 1027       | MCM     | Mochimo                           |
 | 1028       | PLS     | Pulse Coin                        |
+| 1029       | ZIG     | Zig Zag                           |
 | 1030       | XYNC    | Xync Network                      |
 | 1032       | BTCR    | BTCR                              |
 | 1042       | MFID    | Moonfish ID                       |


### PR DESCRIPTION
Adds a coin type for Zig Zag.

- **Coin type:** 1029 (next available unassigned number in this range; 1028 = Pulse Coin, 1030 = Xync Network — verified unassigned at time of submission)
- **Symbol:** ZIG
- **Coin:** Zig Zag
- **Derivation path:** `m/44'/1029'/0'/0/0`

Zig Zag is a proof-of-work/proof-of-stake hybrid Layer 1 (dcrd-derived codebase, ML-DSA post-quantum signature support planned).

Per the requirement that a coin type is added only when a wallet implements BIP-0044 for the desired coin: the Zig Zag wallet (a dcrwallet fork) implements classical BIP-44 hierarchical deterministic derivation (`m/44'/coin_type'/account'`) and will use coin type 1029:

https://github.com/zigzagcore/zigzag-core

- No existing entries were modified; the list remains sorted.
