### PR TITLE
slip-0044: add Animica (ANM)

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1447,6 +1447,7 @@ The hardened path component for coin type `n` is computed as `0x80000000 + n`.
 | 1712144    | LAX     | LAPO                              |
 | 3924011    | EPK     | EPIK Protocol                     |
 | 4151811    | DORK    | Dorkcoin                          |
+| 4279885    | ANM     | Animica                           |
 | 4346950    | BITFLASH | Bitflash                         |
 | 4353123    | BBLU    | Bitcoin-Blu                       |
 | 4392018    | MCSH    | MetaMask Cash Account             |

--- a/slip-0173.md
+++ b/slip-0173.md
@@ -33,6 +33,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | Andromeda                | `andr`        |          |             |
 | Alaya                    | `atp`         | `atx`    |             |
 | Althea                   | `althea`      |          |             |
+| Animica                  | `anim`        |          |             |
 | Archway                  | `archway`     | `const`  |             |
 | Apc                      | `apc`         |          |             |
 | Arkhadian                | `arkh`        |          |             |


### PR DESCRIPTION
Registers **Animica (ANM)** in SLIP-0044 and its bech32m HRP in SLIP-0173.

- Coin type **4279885** = `0x414E4D` = ASCII `"ANM"` (same vanity convention as existing entries, e.g. 4346950). Unused in the table and not claimed by any open PR.
- SLIP-0173: HRP **`anim`** (bech32m), mainnet only.

Animica is a live proof-of-work L1 (mainnet since 2026-04) using post-quantum ML-DSA-65 (FIPS 204) signatures. The BIP-44 path `m/44'/4279885'/0'/0'/0'` (all hardened, SLIP-0010 HMAC-SHA512 derivation) is implemented in the reference wallet library and is the path used by the browser-extension wallet; Wallet PRs using this path: Edge EdgeApp/edge-currency-accountbased#1091 and enKrypt enkryptcom/enKrypt#817 (CAIP namespace: ChainAgnostic/namespaces#200; icons: 0xa3k5/web3icons#214).

- Spec: https://github.com/animicaorg/all/blob/36f995f241cd3e54f66c7a5a6f373d4587bbc60d/docs/wallet/HD_DERIVATION.md
- Reference implementation: https://github.com/animicaorg/all/blob/36f995f241cd3e54f66c7a5a6f373d4587bbc60d/packages/animica-crypto/src/hd.ts
- Wallet: https://github.com/animicaorg/all/tree/main/apps/wallet-extension
- Website: https://animica.org · Explorer: https://explorer.animica.org · Source: https://github.com/animicaorg/all
- ANM is traded on NonKYC: https://nonkyc.io/market/ANM_USDT

Checks: `./check.sh` and `markdownlint -c markdownlint.json slip-0044.md slip-0173.md` produce output identical to current `master` (the 3 pre-existing lint findings are on untouched rows); `git diff --stat` is 2 files, +2 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mj19WF7SsZ4sSkaNat12rq
