### PR TITLE
slip-0044: add 0G

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1362,6 +1362,7 @@ The hardened path component for coin type `n` is computed as `0x80000000 + n`.
 | 14159      | FBC     | Fistbump                          |
 | 15845      | SDGO    | SanDeGo                           |
 | 16181      | XTX     | Totem Live Network                |
+| 16661      | 0G      | 0G                                |
 | 16754      | ARDR    | Ardor                             |
 | 18000      | MTR     | Meter                             |
 | 18888      | BTGS    | BitcoinGold                       |


### PR DESCRIPTION
Adds 0G to the SLIP-0044 registered coin types.

- Coin type: 16661 (matches the EVM chain ID, hardened path component 0x80004115)
- Symbol: 0G
- 0G is a live EVM Layer 1 mainnet (launched September 2025): https://0g.ai
- Chain ID 16661: https://chainlist.org/chain/16661
- Explorer: https://chainscan.0g.ai
- Docs: https://docs.0g.ai
- Wallets implementing BIP-0044 for 0G: OKX Wallet supports 0G natively; MetaMask via Chainlist.