### PR TITLE
slip-0044: add MONEU (coin type 8328)

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1306,6 +1306,7 @@ The hardened path component for coin type `n` is computed as `0x80000000 + n`.
 | 8217       | KAIA    | KAIA                              |
 | 8282       | HANEUL  | Haneul                            |
 | 8327       | RXB     | Record X-core Blockchain          |
+| 8328       | MONEU   | MONEU                             |
 | 8339       | BTQ     | BitcoinQuark                      |
 | 8444       | XCH     | Chia                              |
 | 8453       |         | Base                              |


### PR DESCRIPTION
Adds MONEU to the registry.

The wallet implements BIP-44 with derivation path m/44'/8328'/0'/0/index

Source: https://github.com/natusor/MONEU