### PR TITLE
slip-0044: add HRTH (coin type 9138)

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1331,6 +1331,7 @@ The hardened path component for coin type `n` is computed as `0x80000000 + n`.
 | 9005       | AVAXC   | Avalanche C-Chain                 |
 | 9006       | BSC     | Binance Smart Chain               |
 | 9007       | SATOX   | Satoxcoin                         |
+| 9138       | HRTH    | Hearth                            |
 | 9333       | B3C     | B3Chain                           |
 | 9339       | BRVA    | Brisvia                           |
 | 9345       | WEIL    | Weilliptic                        |


### PR DESCRIPTION
Adds HRTH to the registry.

The wallet implements BIP-44 with derivation path `m/44'/9381'/account'/0'/0'` for transaction signing keys and `m/44'/9381'/account'/1'/0'` for VRF signing keys.

Source: [hearthchain/crypto](https://github.com/hearthchain/crypto#key-derivation--separation), [hearthchain/node-jvm](https://github.com/hearthchain/node-jvm)