### PR TITLE
Add Nyen to Registry (#1031)

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1062,6 +1062,7 @@ The hardened path component for coin type `n` is computed as `0x80000000 + n`.
 | 1028       | PLS     | Pulse Coin                        |
 | 1029       | ZIG     | Zig Zag                           |
 | 1030       | XYNC    | Xync Network                      |
+| 1031       | NYEN    | Nyen                              |
 | 1032       | BTCR    | BTCR                              |
 | 1042       | MFID    | Moonfish ID                       |
 | 1100       | CROSS   | Cross Chain                       |


### PR DESCRIPTION
Registering coin type 1031 for Nyen (NYEN).

NYEN is a secure proof-of-work cryptocurrency operating on a fully independent blockchain with its own genesis block, network magic bytes, address format, consensus rules, P2P network, and RPC interface. It does not share chain parameters with another network.

Consensus and mining
NYEN uses NekoHash, a custom CPU-mineable and ASIC-resistant proof-of-work algorithm designed to keep mining accessible to commodity hardware and reduce hashpower centralization. The chain also supports Sapling shielded transactions for private transfers.

Address format
Transparent addresses use the N… prefix, while Sapling shielded addresses use the zn… prefix.

Token layer
NYEN includes the Nyen Token Standard (NTS), a native token system built directly into the base chain rather than implemented through smart contracts. NTS tokens support on-chain metadata, consensus-enforced maximum supply limits, and standard wallet transfers.

1031 is the first unallocated index (0-1030 all have rows; 1031 has none).


https://nyen.cc/
https://pool.nyen.cc/
https://explorer.nyen.cc/
https://x.com/NyenCoin
https://discord.gg/2TYVYmnE2C